### PR TITLE
[CHORE] Redis Cluster 전환 대비 Lua 스크립트 해시태그 통일

### DIFF
--- a/src/main/java/com/sudo/raillo/booking/application/facade/PendingBookingFacade.java
+++ b/src/main/java/com/sudo/raillo/booking/application/facade/PendingBookingFacade.java
@@ -45,7 +45,7 @@ public class PendingBookingFacade {
 
 	/**
 	 * 예약 생성
-	 * 조회 → 검증 → 운임 계산 → 좌석 Hold -> DB 충돌 검증 →  → PendingBooking 저장
+	 * 조회 → 검증 → 운임 계산 → Seat Hold -> DB 충돌 검증 → PendingBooking 저장
 	 */
 	public PendingBookingCreateResponse createPendingBooking(PendingBookingCreateRequest request, String memberNo) {
 		// 1. 조회
@@ -75,7 +75,7 @@ public class PendingBookingFacade {
 			carType
 		);
 
-		// 4. 좌석 Hold
+		// 4. Seat Hold
 		String pendingBookingId = pendingBookingIdGenerator.generate();
 		Long trainCarId = trainSeatQueryService.getTrainCarId(request.seatIds());
 		seatHoldService.holdSeats(
@@ -97,7 +97,7 @@ public class PendingBookingFacade {
 				request.seatIds()
 			);
 
-			// 6. PendingBooking 저장 (Hold 이후 실패 시 보상 로직)
+			// 6. PendingBooking 저장 (Seat Hold 이후 실패 시 보상 로직)
 			PendingBooking pendingBooking = pendingBookingService.createPendingBooking(
 				pendingBookingId,
 				trainSchedule,
@@ -112,7 +112,7 @@ public class PendingBookingFacade {
 
 			return new PendingBookingCreateResponse(pendingBooking.getId());
 		} catch (Exception e) {
-			log.error("[PendingBooking 저장 실패 - Hold 롤백] pendingBookingId={}, error={}", pendingBookingId, e.getMessage());
+			log.error("[PendingBooking 저장 실패 - Seat Hold 롤백] pendingBookingId={}, error={}", pendingBookingId, e.getMessage());
 			seatHoldService.releaseSeats(
 				pendingBookingId,
 				request.trainScheduleId(),
@@ -127,7 +127,7 @@ public class PendingBookingFacade {
 
 	/**
 	 * 예약 삭제
-	 * PendingBooking 삭제 (취소 확정) → 좌석 Hold 해제 (best-effort 정리)
+	 * PendingBooking 삭제 (취소 확정) → Seat Hold 해제 (best-effort 정리)
 	 */
 	public void deletePendingBookings(List<String> pendingBookingIds, String memberNo) {
 		List<PendingBooking> pendingBookings = pendingBookingService.getPendingBookings(pendingBookingIds, memberNo);

--- a/src/main/java/com/sudo/raillo/booking/application/service/SeatHoldService.java
+++ b/src/main/java/com/sudo/raillo/booking/application/service/SeatHoldService.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
- * 좌석 임시 점유 서비스
+ * Seat Hold 서비스
  *
  * 비즈니스 로직과 Redis 작업 조율
  */
@@ -27,21 +27,21 @@ public class SeatHoldService {
 	private final SeatHoldRepository seatHoldRepository;
 	private final SeatHoldKeyGenerator seatHoldKeyGenerator;
 
-	private static final Duration HOLD_TTL_BUFFER = Duration.ofMinutes(1);
+	private static final Duration SEAT_HOLD_TTL_BUFFER = Duration.ofMinutes(1);
 
 	/**
-	 * 좌석 임시 점유 시도
+	 * Seat Hold 시도
 	 * PendingBooking 생성 전에 호출하여 충돌 검사 수행
 	 *
-	 * <p>Hold TTL은 PendingBooking TTL보다 1분 길게 설정하여
-	 * PendingBooking이 만료되기 전에 Hold가 먼저 사라지는 것을 방지한다.</p>
+	 * <p>Seat Hold TTL은 PendingBooking TTL보다 1분 길게 설정하여
+	 * PendingBooking이 만료되기 전에 Seat Hold가 먼저 사라지는 것을 방지한다.</p>
 	 *
-	 * @param pendingBookingId 미리 생성한 UUID (Hold 키 식별자)
+	 * @param pendingBookingId 미리 생성한 UUID (Seat Hold 키 식별자)
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param departureStop 출발 정차역
 	 * @param arrivalStop 도착 정차역
 	 * @param seatIds 점유할 좌석 ID 목록
-	 * @param trainCarId 객차 ID (Hold Index 키 생성용)
+	 * @param trainCarId 객차 ID (TrainCar Hold Index 키 생성용)
 	 * @param pendingBookingTtl PendingBooking TTL
 	 * @throws BusinessException 좌석 충돌 시 예외 발생
 	 */
@@ -60,18 +60,18 @@ public class SeatHoldService {
 		log.info("[좌석 Hold 요청] pendingBookingId={}, trainScheduleId={}, trainCarId={}, stopOrder={}->{}, seatCount={}",
 			pendingBookingId, trainScheduleId, trainCarId, departureStopOrder, arrivalStopOrder, seatIds.size());
 
-		Duration holdTtl = pendingBookingTtl.plus(HOLD_TTL_BUFFER);
-		tryHoldSeats(trainScheduleId, seatIds, pendingBookingId, departureStopOrder, arrivalStopOrder, trainCarId, holdTtl);
+		Duration seatHoldTtl = pendingBookingTtl.plus(SEAT_HOLD_TTL_BUFFER);
+		tryHoldSeats(trainScheduleId, seatIds, pendingBookingId, departureStopOrder, arrivalStopOrder, trainCarId, seatHoldTtl);
 	}
 
 	/**
-	 * 좌석 점유 해제
+	 * Seat Hold 해제
 	 * TTL 만료 전 수동 해제 필요 시 사용
 	 *
 	 * @param pendingBookingId 예약 ID
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param seatIds pendingBooking에 속하는 좌석 ID 리스트
-	 * @param trainCarId 객차 ID (Hold Index 키 생성용)
+	 * @param trainCarId 객차 ID (TrainCar Hold Index 키 생성용)
 	 * @param departureStopOrder 출발역 stopOrder
 	 * @param arrivalStopOrder 도착역 stopOrder
 	 */
@@ -88,7 +88,7 @@ public class SeatHoldService {
 
 		for (Long seatId : seatIds) {
 			try {
-				seatHoldRepository.releaseHold(
+				seatHoldRepository.releaseSeatHold(
 					trainScheduleId,
 					seatId,
 					pendingBookingId,
@@ -103,16 +103,16 @@ public class SeatHoldService {
 	}
 
 	/**
-	 * CarType별 Hold 점유 좌석 수 계산 (Lua 스크립트 기반)
+	 * CarType별 Seat Hold 점유 좌석 수 계산 (Lua 스크립트 기반)
 	 *
-	 * <p>전달받은 trainCarIds에 대해 Lua 스크립트로 Hold Index를 조회하여 Hold 좌석 수를 계산</p>
+	 * <p>전달받은 trainCarIds에 대해 Lua 스크립트로 TrainCar Hold Index를 조회하여 Seat Hold 좌석 수를 계산</p>
 	 * <p>Lua 내부에서 section 필터링 + seatId 중복 제거를 수행</p>
 	 *
 	 * @param trainScheduleId 스케줄 ID
 	 * @param trainCarIds 조회할 객차 ID 목록 (동일 CarType, Facade에서 RDB 조회 후 전달)
 	 * @param departureStopOrder 출발역 stopOrder
 	 * @param arrivalStopOrder 도착역 stopOrder
-	 * @return Hold 점유 좌석 수
+	 * @return Seat Hold 점유 좌석 수
 	 */
 	public int getHoldSeatsCount(
 		Long trainScheduleId,
@@ -125,16 +125,16 @@ public class SeatHoldService {
 		}
 
 		List<String> searchSections = seatHoldKeyGenerator.generateSections(departureStopOrder, arrivalStopOrder);
-		int holdCount = seatHoldRepository.getHoldSeatsCount(trainScheduleId, trainCarIds, searchSections);
+		int seatHoldCount = seatHoldRepository.getHoldSeatsCount(trainScheduleId, trainCarIds, searchSections);
 
-		log.debug("[Hold 점유 수 계산] trainScheduleId={}, trainCarIds={}, stopOrder={}->{}, holdCount={}",
-			trainScheduleId, trainCarIds, departureStopOrder, arrivalStopOrder, holdCount);
+		log.debug("[Seat Hold 점유 수 계산] trainScheduleId={}, trainCarIds={}, stopOrder={}->{}, seatHoldCount={}",
+			trainScheduleId, trainCarIds, departureStopOrder, arrivalStopOrder, seatHoldCount);
 
-		return holdCount;
+		return seatHoldCount;
 	}
 
 	/**
-	 * 특정 객차에서 Hold된 개별 좌석 ID 목록 조회
+	 * 특정 객차에서 Seat Hold된 개별 좌석 ID 목록 조회
 	 *
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param trainCarId 객차 ID
@@ -152,9 +152,9 @@ public class SeatHoldService {
 	}
 
 	/**
-	 * 여러 좌석 동시 임시 점유 시도
+	 * 여러 좌석 동시 Seat Hold 시도
 	 *
-	 * <p>모든 좌석에 대해 순차적으로 Hold를 시도하고,
+	 * <p>모든 좌석에 대해 순차적으로 Seat Hold를 시도하고,
 	 * 하나라도 실패하면 이미 성공한 좌석들을 롤백함</p>
 	 */
 	private void tryHoldSeats(
@@ -164,7 +164,7 @@ public class SeatHoldService {
 		int departureStopOrder,
 		int arrivalStopOrder,
 		Long trainCarId,
-		Duration holdTtl
+		Duration seatHoldTtl
 	) {
 		log.info("[다중 좌석 Hold 시도] trainScheduleId={}, seatIds={}, pendingBookingId={}",
 			trainScheduleId, seatIds, pendingBookingId);
@@ -173,8 +173,8 @@ public class SeatHoldService {
 
 		try {
 			for (Long seatId : seatIds) {
-				SeatHoldResult result = seatHoldRepository.tryHold(
-					trainScheduleId, seatId, pendingBookingId, departureStopOrder, arrivalStopOrder, trainCarId, holdTtl);
+				SeatHoldResult result = seatHoldRepository.trySeatHold(
+					trainScheduleId, seatId, pendingBookingId, departureStopOrder, arrivalStopOrder, trainCarId, seatHoldTtl);
 
 				if (!result.success()) {
 					rollbackHolds(

--- a/src/main/java/com/sudo/raillo/booking/application/validator/BookingValidator.java
+++ b/src/main/java/com/sudo/raillo/booking/application/validator/BookingValidator.java
@@ -150,7 +150,7 @@ public class BookingValidator {
 
 	/**
 	 * 결제 준비 시 좌석 충돌 검증
-	 * <p>Redis Hold 구간과 DB SeatBooking 구간 비교</p>
+	 * <p>Seat Hold 구간과 DB SeatBooking 구간 비교</p>
 	 * @param pendingBookings 결제할 PendingBooking 목록
 	 */
 	public void validateSeatConflicts(List<PendingBooking> pendingBookings) {

--- a/src/main/java/com/sudo/raillo/booking/exception/BookingError.java
+++ b/src/main/java/com/sudo/raillo/booking/exception/BookingError.java
@@ -55,7 +55,7 @@ public enum BookingError implements ErrorCode {
 	SEAT_CONFLICT_WITH_SOLD("이미 판매된 좌석이 존재하는 구간입니다.", HttpStatus.CONFLICT, "B_304"),
 	SEAT_CONFLICT_WITH_HOLD("다른 사용자가 임시 점유 중인 구간입니다.", HttpStatus.CONFLICT, "B_305"),
 
-	// 좌석 Hold 관련
+	// Seat Hold 관련
 	SEAT_HOLD_SCRIPT_ERROR("좌석 점유 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_306"),
 	SEAT_HOLD_NOT_FOUND("임시 점유 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_307"),
 	SEAT_HOLD_CONFIRM_FAILED("좌석 확정 처리에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_308"),

--- a/src/main/java/com/sudo/raillo/booking/infrastructure/SeatHoldRepository.java
+++ b/src/main/java/com/sudo/raillo/booking/infrastructure/SeatHoldRepository.java
@@ -14,9 +14,9 @@ import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Repository;
 
 /**
- * 좌석 임시 점유(Hold) Redis Repository
+ * Seat Hold Redis Repository
  *
- * <p>Lua 스크립트를 사용하여 좌석 구간 충돌 검사 및 임시 점유를 원자적으로 처리</p>
+ * <p>Lua 스크립트를 사용하여 좌석 구간 충돌 검사 및 Seat Hold를 원자적으로 처리</p>
  *
  * <h3>Lua 스크립트 실행 흐름</h3>
  * <ol>
@@ -41,30 +41,30 @@ public class SeatHoldRepository {
 	private final DefaultRedisScript<Long> getHoldSeatsCountScript;
 
 	/**
-	 * 좌석 임시 점유 시도
+	 * Seat Hold 시도
 	 *
-	 * <p>Lua 스크립트로 충돌 검사 + Hold 생성을 원자적으로 처리</p>
+	 * <p>Lua 스크립트로 충돌 검사 + Seat Hold 생성을 원자적으로 처리</p>
 	 *
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param seatId 좌석 ID
-	 * @param pendingBookingId 예약 ID (Hold 키 식별자)
+	 * @param pendingBookingId 예약 ID (Seat Hold 키 식별자)
 	 * @param departureStopOrder 출발역 stopOrder
 	 * @param arrivalStopOrder 도착역 stopOrder
-	 * @param trainCarId 객차 ID (Hold Index 키 생성용)
-	 * @param holdTtl Hold TTL
+	 * @param trainCarId 객차 ID (TrainCar Hold Index 키 생성용)
+	 * @param seatHoldTtl Seat Hold TTL
 	 * @return SeatHoldResult 점유 결과 (성공/실패 + 충돌 정보)
 	 */
-	public SeatHoldResult tryHold(
+	public SeatHoldResult trySeatHold(
 		Long trainScheduleId,
 		Long seatId,
 		String pendingBookingId,
 		int departureStopOrder,
 		int arrivalStopOrder,
 		Long trainCarId,
-		Duration holdTtl
+		Duration seatHoldTtl
 	) {
-		long holdTtlSeconds = Math.max(1L, holdTtl.toSeconds());
-		String holdKey = seatHoldKeyGenerator.generateHoldKey(trainScheduleId, seatId, pendingBookingId);
+		long seatHoldTtlSeconds = Math.max(1L, seatHoldTtl.toSeconds());
+		String seatHoldKey = seatHoldKeyGenerator.generateSeatHoldKey(trainScheduleId, seatId, pendingBookingId);
 		String seatHoldIndexKey = seatHoldKeyGenerator.generateSeatHoldIndexKey(trainScheduleId, seatId);
 		List<String> sections = seatHoldKeyGenerator.generateSections(departureStopOrder, arrivalStopOrder);
 
@@ -75,30 +75,30 @@ public class SeatHoldRepository {
 
 		try {
 			// Lua 스크립트 실행
-			// - KEYS: [holdKey, seatHoldIndexKey, trainCarHoldIndexKey] - Redis 키들
+			// - KEYS: [seatHoldKey, seatHoldIndexKey, trainCarHoldIndexKey] - Redis 키들
 			// - ARGV: [ttl, pendingBookingId, seatId, section1, section2, ...] - 인자들
 			// - 반환: List<Object> (Lua table이 Java List로 변환됨)
-			Object[] args = buildHoldArgs(pendingBookingId, seatId, sections, holdTtlSeconds);
+			Object[] args = buildSeatHoldArgs(pendingBookingId, seatId, sections, seatHoldTtlSeconds);
 
 			@SuppressWarnings("unchecked")  // DefaultRedisScript<List>의 raw type 때문에 필요
 			List<Object> result = customStringRedisTemplate.execute(
 				seatHoldScript,
-				List.of(holdKey, seatHoldIndexKey, trainCarHoldIndexKey),
+				List.of(seatHoldKey, seatHoldIndexKey, trainCarHoldIndexKey),
 				args
 			);
 
 			// Lua 결과 파싱 (타입 캐스팅 + 예외 처리 포함)
-			SeatHoldResult holdResult = SeatHoldResult.fromLuaResult(result);
+			SeatHoldResult seatHoldResult = SeatHoldResult.fromLuaResult(result);
 
-			if (holdResult.success()) {
+			if (seatHoldResult.success()) {
 				log.info("[좌석 Hold 성공] trainScheduleId={}, seatId={}, pendingBookingId={}",
 					trainScheduleId, seatId, pendingBookingId);
 			} else {
 				log.warn("[좌석 Hold 실패] trainScheduleId={}, seatId={}, status={}, conflictSection={}",
-					trainScheduleId, seatId, holdResult.status(), holdResult.conflictSection());
+					trainScheduleId, seatId, seatHoldResult.status(), seatHoldResult.conflictSection());
 			}
 
-			return holdResult;
+			return seatHoldResult;
 
 		} catch (Exception e) {
 			log.error("[좌석 Hold 스크립트 오류] trainScheduleId={}, seatId={}, error={}",
@@ -108,19 +108,19 @@ public class SeatHoldRepository {
 	}
 
 	/**
-	 * 좌석 점유 해제
+	 * Seat Hold 해제
 	 *
 	 * <p>예약 취소 시 또는 TTL 만료 전 수동 해제가 필요할 때 사용.
-	 * Hold가 이미 없어도 에러 발생하지 않음 (멱등성)</p>
+	 * Seat Hold가 이미 없어도 에러 발생하지 않음 (멱등성)</p>
 	 *
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param seatId 좌석 ID
 	 * @param pendingBookingId 예약 ID
-	 * @param trainCarId 객차 ID (Hold Index 키 생성용)
+	 * @param trainCarId 객차 ID (TrainCar Hold Index 키 생성용)
 	 * @param departureStopOrder 출발역 stopOrder (sections 생성용)
 	 * @param arrivalStopOrder 도착역 stopOrder (sections 생성용)
 	 */
-	public void releaseHold(
+	public void releaseSeatHold(
 		Long trainScheduleId,
 		Long seatId,
 		String pendingBookingId,
@@ -128,7 +128,7 @@ public class SeatHoldRepository {
 		int departureStopOrder,
 		int arrivalStopOrder
 	) {
-		String holdKey = seatHoldKeyGenerator.generateHoldKey(trainScheduleId, seatId, pendingBookingId);
+		String seatHoldKey = seatHoldKeyGenerator.generateSeatHoldKey(trainScheduleId, seatId, pendingBookingId);
 		String seatHoldIndexKey = seatHoldKeyGenerator.generateSeatHoldIndexKey(trainScheduleId, seatId);
 		List<String> sections = seatHoldKeyGenerator.generateSections(departureStopOrder, arrivalStopOrder);
 
@@ -142,7 +142,7 @@ public class SeatHoldRepository {
 
 			customStringRedisTemplate.execute(
 				seatReleaseScript,
-				List.of(holdKey, seatHoldIndexKey, trainCarHoldIndexKey),
+				List.of(seatHoldKey, seatHoldIndexKey, trainCarHoldIndexKey),
 				args
 			);
 
@@ -158,22 +158,22 @@ public class SeatHoldRepository {
 
 
 	/**
-	 * CarType별 Hold 점유 좌석 수 계산 (Lua 스크립트 사용)
+	 * CarType별 Seat Hold 점유 좌석 수 계산 (Lua 스크립트 사용)
 	 *
-	 * <p>여러 객차의 Hold Index를 한 번에 조회하여 Hold 점유 좌석 수를 계산</p>
+	 * <p>여러 객차의 TrainCar Hold Index를 한 번에 조회하여 Seat Hold 점유 좌석 수를 계산</p>
 	 * <p>Lua 스크립트에서 section 필터링 및 seatId 중복 제거를 수행</p>
 	 *
 	 * @param trainScheduleId 스케줄 ID
 	 * @param trainCarIds 조회할 객차 ID 목록 (동일 CarType)
 	 * @param sections 검색 구간 목록 (예: ["0-1", "1-2"])
-	 * @return Hold 점유 좌석 수
+	 * @return Seat Hold 점유 좌석 수
 	 */
 	public int getHoldSeatsCount(
 		Long trainScheduleId,
 		List<Long> trainCarIds,
 		List<String> sections
 	) {
-		// KEYS: Hold Index 키 목록 생성
+		// KEYS: TrainCar Hold Index 키 목록 생성
 		List<String> keys = trainCarIds.stream()
 			.map(carId -> seatHoldKeyGenerator.generateTrainCarHoldIndexKey(trainScheduleId, carId))
 			.toList();
@@ -189,17 +189,17 @@ public class SeatHoldRepository {
 			return count.intValue();
 
 		} catch (Exception e) {
-			log.error("[Hold 점유 수 조회 오류] trainScheduleId={}, trainCarIds={}, error={}",
+			log.error("[Seat Hold 점유 수 조회 오류] trainScheduleId={}, trainCarIds={}, error={}",
 				trainScheduleId, trainCarIds, e.getMessage(), e);
-			// Hold는 검색 정확도 보조 데이터이므로 레디스 오류 시 0 반환하여 검색 가용성 유지
+			// Seat Hold는 검색 정확도 보조 데이터이므로 레디스 오류 시 0 반환하여 검색 가용성 유지
 			return 0;
 		}
 	}
 
 	/**
-	 * 특정 객차의 구간에 Hold된 좌석 ID 목록 조회
-	 * <p>Hold Index (Sorted Set)에서 만료되지 않은 멤버를 조회하여 검색 구간과 겹치는 seatId를 수집</p>
-	 * <p>예) trainScheduleId=10, trainCarId=7인 객차에서 ["0-1", "1-2"] 구간과 겹치는 Hold 좌석 ID를 반환한다.</p>
+	 * 특정 객차의 구간에 Seat Hold된 좌석 ID 목록 조회
+	 * <p>TrainCar Hold Index (Sorted Set)에서 만료되지 않은 멤버를 조회하여 검색 구간과 겹치는 seatId를 수집</p>
+	 * <p>예) trainScheduleId=10, trainCarId=7인 객차에서 ["0-1", "1-2"] 구간과 겹치는 Seat Hold 좌석 ID를 반환한다.</p>
 	 *
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param trainCarId 객차 ID
@@ -259,24 +259,24 @@ public class SeatHoldRepository {
 	}
 
 	/**
-	 * Hold 스크립트 인자 배열 구성
+	 * Seat Hold 스크립트 인자 배열 구성
 	 *
 	 * <p>ARGV 형식: [ttl, pendingBookingId, seatId, section1, section2, ...]</p>
 	 *
-	 * @param pendingBookingId 예약 ID (holds 인덱스에 추가할 값)
-	 * @param seatId 좌석 ID (Hold Index 멤버 생성용)
+	 * @param pendingBookingId 예약 ID (Seat Hold Index에 추가할 값)
+	 * @param seatId 좌석 ID (TrainCar Hold Index 멤버 생성용)
 	 * @param sections 구간 목록 (예: ["0-1", "1-2", "2-3"])
-	 * @param holdTtlSeconds hold TTL (초)
+	 * @param seatHoldTtlSeconds Seat Hold TTL (초)
 	 * @return Lua ARGV로 전달할 인자 배열
 	 */
-	private Object[] buildHoldArgs(
+	private Object[] buildSeatHoldArgs(
 		String pendingBookingId,
 		Long seatId,
 		List<String> sections,
-		long holdTtlSeconds
+		long seatHoldTtlSeconds
 	) {
 		Object[] args = new Object[sections.size() + 3];
-		args[0] = String.valueOf(holdTtlSeconds);        // ARGV[1]: TTL
+		args[0] = String.valueOf(seatHoldTtlSeconds);        // ARGV[1]: TTL
 		args[1] = pendingBookingId;                      // ARGV[2]: pendingBookingId
 		args[2] = String.valueOf(seatId);                // ARGV[3]: seatId
 		for (int i = 0; i < sections.size(); i++) {
@@ -286,7 +286,7 @@ public class SeatHoldRepository {
 	}
 
 	/**
-	 * Hold 좌석 수 조회 스크립트 인자 배열 구성
+	 * Seat Hold 좌석 수 조회 스크립트 인자 배열 구성
 	 *
 	 * <p>ARGV 형식: [section1, section2, ...]</p>
 	 * <p>currentTime은 Lua 내부에서 redis.call("TIME")으로 직접 조회 (clock skew 방지)</p>
@@ -303,16 +303,16 @@ public class SeatHoldRepository {
 	}
 
 	/**
-	 * Hold Index 멤버 문자열이 "seatId:section" 형식인지 검증하고 유효한 구분자 ':' 위치를 반환한다.
+	 * TrainCar Hold Index 멤버 문자열이 "seatId:section" 형식인지 검증하고 유효한 구분자 ':' 위치를 반환한다.
 	 *
-	 * @param member Hold Index 멤버 문자열
+	 * @param member TrainCar Hold Index 멤버 문자열
 	 * @return 유효한 ':' 인덱스
 	 * @throws BusinessException 멤버 형식이 잘못된 경우
 	 */
 	private int getValidColonIndex(String member) {
 		int colonIndex = member.indexOf(':');
 		if (colonIndex <= 0 || colonIndex == member.length() - 1) {
-			log.error("[Hold Index 멤버 파싱 오류] 잘못된 포맷. member={}", member);
+			log.error("[TrainCar Hold Index 멤버 파싱 오류] 잘못된 포맷. member={}", member);
 			throw new BusinessException(BookingError.SEAT_HOLD_SCRIPT_ERROR);
 		}
 		return colonIndex;

--- a/src/main/java/com/sudo/raillo/global/config/RedisScriptConfig.java
+++ b/src/main/java/com/sudo/raillo/global/config/RedisScriptConfig.java
@@ -35,7 +35,7 @@ import org.springframework.scripting.support.ResourceScriptSource;
 public class RedisScriptConfig {
 
 	/**
-	 * 좌석 임시 점유 스크립트
+	 * Seat Hold 스크립트
 	 *
 	 * <p>반환값: {@code {성공여부(1/0), 상태문자열, [충돌구간]}}</p>
 	 * <p>예: {@code {1, "HOLD_SUCCESS"}} 또는 {@code {0, "CONFLICT_WITH_HOLD", "1-2"}}</p>
@@ -50,9 +50,9 @@ public class RedisScriptConfig {
 	}
 
 	/**
-	 * 좌석 점유 해제 스크립트
+	 * Seat Hold 해제 스크립트
 	 *
-	 * <p>Hold 키 삭제 및 holds 인덱스에서 제거</p>
+	 * <p>Seat Hold 키 삭제 및 Seat Hold Index에서 제거</p>
 	 * <p>반환값: {@code {1, "RELEASE_SUCCESS"}}</p>
 	 */
 	@Bean
@@ -65,10 +65,10 @@ public class RedisScriptConfig {
 	}
 
 	/**
-	 * Hold 점유 좌석 수 계산 스크립트
+	 * Seat Hold 점유 좌석 수 계산 스크립트
 	 *
-	 * <p>여러 Hold Index를 조회하여 검색 구간과 겹치는 Hold 좌석 수를 계산</p>
-	 * <p>반환값: Hold 점유 좌석 수 (Long)</p>
+	 * <p>여러 TrainCar Hold Index를 조회하여 검색 구간과 겹치는 Seat Hold 좌석 수를 계산</p>
+	 * <p>반환값: Seat Hold 점유 좌석 수 (Long)</p>
 	 */
 	@Bean
 	public DefaultRedisScript<Long> getHoldSeatsCountScript() {

--- a/src/main/java/com/sudo/raillo/global/redis/util/SeatHoldKeyGenerator.java
+++ b/src/main/java/com/sudo/raillo/global/redis/util/SeatHoldKeyGenerator.java
@@ -7,7 +7,7 @@ import java.util.stream.IntStream;
 import org.springframework.stereotype.Component;
 
 /**
- * 좌석 Hold 관련 Redis 키 생성기
+ * Seat Hold 관련 Redis 키 생성기
  */
 @Component
 public class SeatHoldKeyGenerator {
@@ -21,23 +21,23 @@ public class SeatHoldKeyGenerator {
 	private static final String TRAINCAR_HOLD_INDEX_KEY_FORMAT = "{schedule:%d}:traincar:%d:holding-seats";
 
 	/**
-	 * 좌석 임시 점유 키 생성
+	 * Seat Hold 키 생성
 	 * 예: {schedule:1001}:seat:12:hold:pending_abc123
 	 *
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param seatId 좌석 ID
 	 * @param pendingBookingId 예약 ID
 	 */
-	public String generateHoldKey(Long trainScheduleId, Long seatId, String pendingBookingId) {
+	public String generateSeatHoldKey(Long trainScheduleId, Long seatId, String pendingBookingId) {
 		return String.format(SEAT_HOLD_KEY_FORMAT, trainScheduleId, seatId, pendingBookingId);
 	}
 
 	/**
-	 * 좌석 Hold 목록 인덱스 키 생성
+	 * Seat Hold Index 키 생성
 	 *
 	 * <p>예: {@code {schedule:1001}:seat:12:holds}</p>
-	 * <p>해당 좌석의 현재 Hold 목록(pendingBookingId들)을 저장하는 Set의 키</p>
-	 * <p>KEYS 명령 대신 SMEMBERS로 Hold 목록을 조회하기 위한 인덱스 역할</p>
+	 * <p>해당 좌석의 현재 Seat Hold 목록(pendingBookingId들)을 저장하는 Set의 키</p>
+	 * <p>KEYS 명령 대신 SMEMBERS로 Seat Hold 목록을 조회하기 위한 인덱스 역할</p>
 	 *
 	 * @param trainScheduleId 열차 스케줄 ID
 	 * @param seatId 좌석 ID
@@ -48,10 +48,10 @@ public class SeatHoldKeyGenerator {
 	}
 
 	/**
-	 * Hold Index 키 생성
+	 * TrainCar Hold Index 키 생성
 	 *
 	 * <p>예: {@code {schedule:1785}:traincar:231:holding-seats}</p>
-	 * <p>특정 객차의 Hold 좌석을 빠르게 조회하기 위한 Sorted Set 인덱스</p>
+	 * <p>특정 객차의 Seat Hold 좌석을 빠르게 조회하기 위한 Sorted Set 인덱스</p>
 	 * <p>멤버 형식: "seatId:section" (예: "42:0-1"), Score: 만료 시각 (Unix Timestamp)</p>
 	 *
 	 * @param trainScheduleId 열차 스케줄 ID

--- a/src/main/java/com/sudo/raillo/payment/application/PaymentFacade.java
+++ b/src/main/java/com/sudo/raillo/payment/application/PaymentFacade.java
@@ -154,8 +154,8 @@ public class PaymentFacade {
 	}
 
 	/**
-	 * PendingBooking 삭제 및 Hold 해제
-	 * <p>예매가 완료된 PendingBooking에 대해 삭제 및 좌석 Hold 해제를 수행합니다.</p>
+	 * PendingBooking 삭제 및 Seat Hold 해제
+	 * <p>예매가 완료된 PendingBooking에 대해 삭제 및 Seat Hold 해제를 수행합니다.</p>
 	 */
 	private void cleanupPendingBookings(List<PendingBooking> pendingBookings) {
 		List<String> pendingBookingIds = pendingBookings.stream()

--- a/src/main/java/com/sudo/raillo/train/application/calculator/SeatAvailabilityCalculator.java
+++ b/src/main/java/com/sudo/raillo/train/application/calculator/SeatAvailabilityCalculator.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SeatAvailabilityCalculator {
 
 	/**
-	 * 구간별 좌석 상태 계산 (전체 좌석 - SeatBooking - Hold = 잔여석)
+	 * 구간별 좌석 상태 계산 (전체 좌석 - SeatBooking - Seat Hold = 잔여석)
 	 */
 	public SectionSeatStatus calculateSectionSeatStatus(
 		List<SeatBookingInfo> overlappingBookings,

--- a/src/main/java/com/sudo/raillo/train/application/facade/TrainSearchFacade.java
+++ b/src/main/java/com/sudo/raillo/train/application/facade/TrainSearchFacade.java
@@ -128,7 +128,7 @@ public class TrainSearchFacade {
 		List<TrainCarInfo> carsWithConfirmedAvailability = trainSeatQueryService.getAvailableTrainCars(
 			request.trainScheduleId(), request.departureStationId(), request.arrivalStationId());
 
-		// 5. Hold 좌석 차감 적용
+		// 5. Seat Hold 좌석 차감 적용
 		List<TrainCarInfo> availableCars = deductHoldSeats(
 			carsWithConfirmedAvailability, request.trainScheduleId(), departureStop.getStopOrder(), arrivalStop.getStopOrder());
 
@@ -162,7 +162,7 @@ public class TrainSearchFacade {
 		// 1. 객차 좌석 상세 조회
 		TrainCarSeatInfo carSeatInfo = trainSeatQueryService.getTrainCarSeatDetail(request);
 
-		// 2. Hold된 seatId 조회
+		// 2. Seat Hold된 seatId 조회
 		Set<Long> holdSeats = seatHoldService.getSeatIdsOnHold(
 			request.trainScheduleId(),
 			request.trainCarId(),
@@ -170,7 +170,7 @@ public class TrainSearchFacade {
 			carSeatInfo.arrivalStopOrder()
 		);
 
-		// 3. hold를 반영해 좌석 가용 상태 계산 후 응답 생성
+		// 3. Seat Hold를 반영해 좌석 가용 상태 계산 후 응답 생성
 		Set<Long> availableSeatIds = calculateAvailableSeatIds(carSeatInfo, holdSeats);
 		return responseMapper.mapToSeatDetailResponse(carSeatInfo, availableSeatIds);
 	}
@@ -196,7 +196,7 @@ public class TrainSearchFacade {
 		Map<Long, List<SeatBookingInfo>> overlappingBookingsMap = trainSearchService.findOverlappingBookingsBatch(
 			trainScheduleIds, request.departureStationId(), request.arrivalStationId());
 
-		// 2. Hold 조회용 객차 ID 배치 조회
+		// 2. Seat Hold 조회용 객차 ID 배치 조회
 		TrainCarIdsBatch trainCarIdsBatch = trainSearchService.getTrainCarIdsBatch(trainScheduleIds);
 
 		// 3. 각 열차별로 배치 조회된 데이터를 사용해 응답 생성
@@ -240,10 +240,10 @@ public class TrainSearchFacade {
 		Map<CarType, Integer> totalSeatsByCarType = seatInfoBatch.getSeatsCountByCarType(trainScheduleId);
 		// SeatBooking 좌석
 		List<SeatBookingInfo> overlappingBookings = overlappingBookingsMap.getOrDefault(trainScheduleId, List.of());
-		// 열차의 CarType별 Hold 좌석 수 게산
+		// 열차의 CarType별 Seat Hold 좌석 수 계산
 		Map<CarType, Integer> holdSeatsCountByCarType = getHoldSeatsCountByCarType(trainInfo, trainCarIdsBatch);
 
-		// 좌석 상태 계산 (전체 좌석 - SeatBooking - Hold = 잔여석)
+		// 좌석 상태 계산 (전체 좌석 - SeatBooking - Seat Hold = 잔여석)
 		SectionSeatStatus sectionStatus = seatAvailabilityCalculator
 			.calculateSectionSeatStatus(overlappingBookings, totalSeatsByCarType, holdSeatsCountByCarType, passengerCount);
 
@@ -251,7 +251,7 @@ public class TrainSearchFacade {
 	}
 
 	/**
-	 * CarType별 Hold 점유 좌석 수 조회
+	 * CarType별 Seat Hold 점유 좌석 수 조회
 	 */
 	private Map<CarType, Integer> getHoldSeatsCountByCarType(TrainBasicInfo trainInfo, TrainCarIdsBatch trainCarIdsBatch) {
 		Long trainScheduleId = trainInfo.trainScheduleId();
@@ -269,8 +269,8 @@ public class TrainSearchFacade {
 	}
 
 	/**
-	 * 객차별 Hold 좌석 차감 적용
-	 * Hold 차감 후 잔여석이 0인 객차는 목록에서 제외
+	 * 객차별 Seat Hold 좌석 차감 적용
+	 * Seat Hold 차감 후 잔여석이 0인 객차는 목록에서 제외
 	 */
 	private List<TrainCarInfo> deductHoldSeats(
 		List<TrainCarInfo> availableCars,

--- a/src/main/resources/scripts/get_hold_seats_count.lua
+++ b/src/main/resources/scripts/get_hold_seats_count.lua
@@ -1,10 +1,10 @@
 -- get_hold_seats_count.lua
--- CarType별 Hold 점유 좌석 수 계산 Lua 스크립트
+-- CarType별 Seat Hold 점유 좌석 수 계산 Lua 스크립트
 --
--- KEYS[1..N]: Hold Index 키들 (예: {schedule:1785}:traincar:231:holding-seats)
+-- KEYS[1..N]: TrainCar Hold Index 키들 (예: {schedule:1785}:traincar:231:holding-seats)
 -- ARGV[1..M]: 검색 구간 sections (예: "0-1", "1-2", "2-3")
 --
--- 반환값: Hold 점유 좌석 수 (중복 제거된)
+-- 반환값: Seat Hold 점유 좌석 수 (중복 제거된)
 
 -- Redis 서버 시각 사용 (Java 서버와 clock skew 방지)
 local currentTime = tonumber(redis.call("TIME")[1])
@@ -18,9 +18,9 @@ end
 -- seatId 중복 제거용 Set
 local uniqueSeats = {}
 
--- 각 Hold Index 키에 대해 조회
+-- 각 TrainCar Hold Index 키에 대해 조회
 for _, key in ipairs(KEYS) do
-    -- 만료되지 않은 Hold 멤버 조회
+    -- 만료되지 않은 TrainCar Hold Index 멤버 조회
     local members = redis.call("ZRANGEBYSCORE", key, currentTime, "+inf")
 
     for _, member in ipairs(members) do

--- a/src/main/resources/scripts/seat_hold.lua
+++ b/src/main/resources/scripts/seat_hold.lua
@@ -1,12 +1,12 @@
 -- seat_hold.lua
--- 좌석 임시 점유 Lua 스크립트
+-- Seat Hold Lua 스크립트
 --
--- KEYS[1]: hold key      (예: {schedule:1001}:seat:12:hold:pending_abc123)
--- KEYS[2]: holds key     (예: {schedule:1001}:seat:12:holds) - Hold 목록 인덱스
--- KEYS[3]: trainCarHoldIndexKey  (예: {schedule:1785}:traincar:231:holding-seats) - Hold Index
+-- KEYS[1]: Seat Hold 키           (예: {schedule:1001}:seat:12:hold:pending_abc123)
+-- KEYS[2]: Seat Hold Index 키     (예: {schedule:1001}:seat:12:holds)
+-- KEYS[3]: TrainCar Hold Index 키 (예: {schedule:1785}:traincar:231:holding-seats)
 --
 -- ARGV[1]: ttl (seconds)
--- ARGV[2]: pendingBookingId (holds Set에 추가할 값)
+-- ARGV[2]: pendingBookingId (Seat Hold Index에 추가할 값)
 -- ARGV[3]: seatId
 -- ARGV[4...]: sections ("0-1", "1-2", ...)
 --
@@ -14,7 +14,7 @@
 -- 성공: {1, "HOLD_SUCCESS"}
 -- 실패: {0, "CONFLICT_WITH_HOLD", "충돌구간"}
 
-local holdKey = KEYS[1]
+local seatHoldKey = KEYS[1]
 local seatHoldIndexKey = KEYS[2]
 local trainCarHoldIndexKey = KEYS[3]
 local ttl = tonumber(ARGV[1])
@@ -27,26 +27,26 @@ for i = 4, #ARGV do
     table.insert(sections, ARGV[i])
 end
 
--- 1. HOLD 충돌 검사 (다른 사용자의 임시 점유와 겹치는지)
--- holds Set에서 현재 Hold 목록 조회 (KEYS 명령 대신 SMEMBERS 사용)
-local holdIds = redis.call("SMEMBERS", seatHoldIndexKey)
+-- 1. Seat Hold 충돌 검사 (다른 사용자의 Seat Hold와 겹치는지)
+-- Seat Hold Index에서 현재 Seat Hold 목록 조회 (KEYS 명령 대신 SMEMBERS 사용)
+local seatHoldIds = redis.call("SMEMBERS", seatHoldIndexKey)
 
-for _, holdId in ipairs(holdIds) do
+for _, holdId in ipairs(seatHoldIds) do
     -- 자기 자신은 제외 (재시도 케이스 대응)
     if holdId ~= pendingBookingId then
         -- string.gsub은 패턴 매칭을 사용하므로 특수문자('-' 등)가 포함된 ID 처리 시 오류 발생 가능
         -- 따라서 문자열 길이를 기반으로 prefix를 추출하여 단순 결합 방식으로 변경
-        local prefixLen = string.len(holdKey) - string.len(pendingBookingId)
-        local prefix = string.sub(holdKey, 1, prefixLen)
-        local otherHoldKey = prefix .. holdId
+        local prefixLen = string.len(seatHoldKey) - string.len(pendingBookingId)
+        local prefix = string.sub(seatHoldKey, 1, prefixLen)
+        local otherSeatHoldKey = prefix .. holdId
 
-        -- 만료된 Hold 키 정리 (Lazy Cleanup)
-        if redis.call("EXISTS", otherHoldKey) == 0 then
+        -- 만료된 Seat Hold 키 정리 (Lazy Cleanup)
+        if redis.call("EXISTS", otherSeatHoldKey) == 0 then
             redis.call("SREM", seatHoldIndexKey, holdId)
         else
-            -- 유효한 Hold 키인 경우 충돌 검사
+            -- 유효한 Seat Hold 키인 경우 충돌 검사
             for _, s in ipairs(sections) do
-                if redis.call("SISMEMBER", otherHoldKey, s) == 1 then
+                if redis.call("SISMEMBER", otherSeatHoldKey, s) == 1 then
                     return {0, "CONFLICT_WITH_HOLD", s}
                 end
             end
@@ -54,17 +54,17 @@ for _, holdId in ipairs(holdIds) do
     end
 end
 
--- 2. 임시 점유 생성
+-- 2. Seat Hold 생성
 for _, s in ipairs(sections) do
-    redis.call("SADD", holdKey, s)
+    redis.call("SADD", seatHoldKey, s)
 end
-redis.call("EXPIRE", holdKey, ttl)
+redis.call("EXPIRE", seatHoldKey, ttl)
 
--- 3. holds 인덱스에 추가 (TTL 동일하게 설정)
+-- 3. Seat Hold Index에 추가 (TTL 동일하게 설정)
 redis.call("SADD", seatHoldIndexKey, pendingBookingId)
 redis.call("EXPIRE", seatHoldIndexKey, ttl)
 
--- 4. Hold Index에 compound 멤버 등록
+-- 4. TrainCar Hold Index에 compound 멤버 등록
 local currentTime = redis.call("TIME")[1]
 local expiryTime = currentTime + ttl
 

--- a/src/main/resources/scripts/seat_release.lua
+++ b/src/main/resources/scripts/seat_release.lua
@@ -1,19 +1,19 @@
 -- seat_release.lua
--- 좌석 임시 점유 해제 Lua 스크립트
+-- Seat Hold 해제 Lua 스크립트
 --
--- KEYS[1]: hold key      (예: {schedule:1001}:seat:12:hold:pending_abc123)
--- KEYS[2]: holds key     (예: {schedule:1001}:seat:12:holds) - Hold 목록 인덱스
--- KEYS[3]: trainCarHoldIndexKey  (예: {schedule:1785}:traincar:231:holding-seats) - Hold Index
+-- KEYS[1]: Seat Hold 키           (예: {schedule:1001}:seat:12:hold:pending_abc123)
+-- KEYS[2]: Seat Hold Index 키     (예: {schedule:1001}:seat:12:holds)
+-- KEYS[3]: TrainCar Hold Index 키 (예: {schedule:1785}:traincar:231:holding-seats)
 --
--- ARGV[1]: pendingBookingId (holds Set에서 제거할 값)
+-- ARGV[1]: pendingBookingId (Seat Hold Index에서 제거할 값)
 -- ARGV[2]: seatId
--- ARGV[3...]: sections (이 Hold가 점유했던 구간들)
+-- ARGV[3...]: sections (이 Seat Hold가 점유했던 구간들)
 --
 -- 반환값:
 -- 성공: {1, "RELEASE_SUCCESS"}
 -- 키 없음: {1, "ALREADY_RELEASED"} (이미 만료되었거나 해제됨 - 성공으로 처리)
 
-local holdKey = KEYS[1]
+local seatHoldKey = KEYS[1]
 local seatHoldIndexKey = KEYS[2]
 local trainCarHoldIndexKey = KEYS[3]
 local pendingBookingId = ARGV[1]
@@ -25,13 +25,13 @@ for i = 3, #ARGV do
     table.insert(sections, ARGV[i])
 end
 
--- 1. Hold 키 삭제 (없어도 에러 아님)
-local deleted = redis.call("DEL", holdKey)
+-- 1. Seat Hold 키 삭제 (없어도 에러 아님)
+local deleted = redis.call("DEL", seatHoldKey)
 
--- 2. holds 인덱스에서 제거
+-- 2. Seat Hold Index에서 제거
 redis.call("SREM", seatHoldIndexKey, pendingBookingId)
 
--- 3. Hold Index 정리
+-- 3. TrainCar Hold Index 정리
 for _, s in ipairs(sections) do
     local member = seatId .. ":" .. s
     redis.call("ZREM", trainCarHoldIndexKey, member)

--- a/src/test/java/com/sudo/raillo/booking/application/facade/PendingBookingFacadeTest.java
+++ b/src/test/java/com/sudo/raillo/booking/application/facade/PendingBookingFacadeTest.java
@@ -86,7 +86,7 @@ class PendingBookingFacadeTest {
 	}
 
 	@Test
-	@DisplayName("예약 삭제 시 좌석 Hold가 해제된다")
+	@DisplayName("예약 삭제 시 Seat Hold가 해제된다")
 	void deletePendingBookings_success_holdReleased() {
 		// given
 		String memberNo = "202601010001";
@@ -118,7 +118,7 @@ class PendingBookingFacadeTest {
 		pendingBookingFacade.deletePendingBookings(List.of(pendingBooking.getId()), memberNo);
 
 		// then - Hold가 해제되어 다른 사용자가 같은 좌석을 Hold 할 수 있어야 함
-		SeatHoldResult result = seatHoldRepository.tryHold(
+		SeatHoldResult result = seatHoldRepository.trySeatHold(
 			trainScheduleResult.trainSchedule().getId(),
 			seatId,
 			"other-pending-booking",
@@ -152,7 +152,7 @@ class PendingBookingFacadeTest {
 	}
 
 	@Test
-	@DisplayName("PendingBooking 저장 실패 시 Hold가 롤백된다")
+	@DisplayName("PendingBooking 저장 실패 시 Seat Hold가 롤백된다")
 	void createPendingBooking_saveFail_holdRollback() {
 		// given
 		String memberNo = "202601010001";
@@ -189,7 +189,7 @@ class PendingBookingFacadeTest {
 		int arrivalStopOrder = trainScheduleResult.scheduleStops().get(2).getStopOrder();
 		Long trainCarId = seats.get(0).getTrainCar().getId();
 
-		SeatHoldResult result = seatHoldRepository.tryHold(
+		SeatHoldResult result = seatHoldRepository.trySeatHold(
 			trainScheduleResult.trainSchedule().getId(),
 			seats.get(0).getId(),
 			"other-pending-booking",

--- a/src/test/java/com/sudo/raillo/booking/application/service/SeatHoldServiceTest.java
+++ b/src/test/java/com/sudo/raillo/booking/application/service/SeatHoldServiceTest.java
@@ -99,7 +99,7 @@ class SeatHoldServiceTest {
 		}
 
 		@Test
-		@DisplayName("Hold TTL은 PendingBooking TTL보다 1분 길게 설정된다")
+		@DisplayName("Seat Hold TTL은 PendingBooking TTL보다 1분 길게 설정된다")
 		void holdSeats_success_holdTtlHasBuffer() {
 			// given
 			String pendingBookingId = "pending-booking-ttl-001";
@@ -122,12 +122,12 @@ class SeatHoldServiceTest {
 			);
 
 			// then - Hold TTL이 PendingBooking TTL + 1분(60초) = 180초
-			String holdKey = seatHoldKeyGenerator.generateHoldKey(trainScheduleId, seatIds.get(0), pendingBookingId);
+			String seatHoldKey = seatHoldKeyGenerator.generateSeatHoldKey(trainScheduleId, seatIds.get(0), pendingBookingId);
 			String seatHoldIndexKey = seatHoldKeyGenerator.generateSeatHoldIndexKey(trainScheduleId, seatIds.get(0));
-			Long holdKeyTtl = customStringRedisTemplate.getExpire(holdKey, TimeUnit.SECONDS);
+			Long seatHoldKeyTtl = customStringRedisTemplate.getExpire(seatHoldKey, TimeUnit.SECONDS);
 			Long seatHoldIndexKeyTtl = customStringRedisTemplate.getExpire(seatHoldIndexKey, TimeUnit.SECONDS);
 
-			assertThat(holdKeyTtl).isBetween(170L, 180L);
+			assertThat(seatHoldKeyTtl).isBetween(170L, 180L);
 			assertThat(seatHoldIndexKeyTtl).isBetween(170L, 180L);
 		}
 
@@ -161,7 +161,7 @@ class SeatHoldServiceTest {
 		}
 
 		@Test
-		@DisplayName("다른 사용자가 Hold 중인 좌석 점유 시도 시 충돌 예외가 발생한다")
+		@DisplayName("다른 사용자가 Seat Hold 중인 좌석 점유 시도 시 충돌 예외가 발생한다")
 		void holdSeats_conflictWithHold_fail() {
 			// given
 			String pendingBookingId1 = "pending-booking-001";
@@ -183,7 +183,7 @@ class SeatHoldServiceTest {
 				Duration.ofMinutes(10)
 			);
 
-			// when & then - 두 번째 사용자가 같은 좌석 Hold 시도
+			// when & then - 두 번째 사용자가 같은 좌석 Seat Hold 시도
 			assertThatThrownBy(() ->
 				seatHoldService.holdSeats(
 					pendingBookingId2,
@@ -217,7 +217,7 @@ class SeatHoldServiceTest {
 			Long trainCarId = seats.get(0).getTrainCar().getId();
 
 			// 좌석 2번에 먼저 Hold
-			seatHoldRepository.tryHold(trainScheduleId, seat2Id, pendingBookingId1, departureStopOrder, arrivalStopOrder, trainCarId, Duration.ofMinutes(10));
+			seatHoldRepository.trySeatHold(trainScheduleId, seat2Id, pendingBookingId1, departureStopOrder, arrivalStopOrder, trainCarId, Duration.ofMinutes(10));
 
 			// when - 좌석 1, 2, 3 동시 Hold 시도 (2번에서 충돌)
 			assertThatThrownBy(() ->
@@ -235,14 +235,14 @@ class SeatHoldServiceTest {
 				.hasMessage(BookingError.SEAT_CONFLICT_WITH_HOLD.getMessage());
 
 			// then - 좌석 1번도 롤백되어 Hold 가능해야 함
-			SeatHoldResult result = seatHoldRepository.tryHold(
+			SeatHoldResult result = seatHoldRepository.trySeatHold(
 				trainScheduleId, seat1Id, "pending-booking-003", departureStopOrder, arrivalStopOrder, trainCarId, Duration.ofMinutes(10)
 			);
 			assertThat(result.success()).isTrue();
 		}
 
 		@Test
-		@DisplayName("겹치지 않는 구간은 같은 좌석이라도 Hold 가능하다")
+		@DisplayName("겹치지 않는 구간은 같은 좌석이라도 Seat Hold 가능하다")
 		void holdSeats_nonOverlappingSections_success() {
 			// given
 			String pendingBookingId1 = "pending-booking-001";
@@ -325,7 +325,7 @@ class SeatHoldServiceTest {
 		}
 
 		@Test
-		@DisplayName("점유 해제 후 같은 좌석을 다시 Hold 할 수 있다")
+		@DisplayName("점유 해제 후 같은 좌석을 다시 Seat Hold 할 수 있다")
 		void releaseSeats_thenHoldAgain_success() {
 			// given
 			String pendingBookingId1 = "pending-booking-001";
@@ -357,7 +357,7 @@ class SeatHoldServiceTest {
 				arrivalStop.getStopOrder()
 			);
 
-			// when & then - 두 번째 사용자가 같은 좌석 Hold 성공
+			// when & then - 두 번째 사용자가 같은 좌석 Seat Hold 성공
 			assertThatCode(() ->
 				seatHoldService.holdSeats(
 					pendingBookingId2,
@@ -410,7 +410,7 @@ class SeatHoldServiceTest {
 			).doesNotThrowAnyException();
 
 			// 해제 후 다시 Hold 가능 확인
-			SeatHoldResult result = seatHoldRepository.tryHold(
+			SeatHoldResult result = seatHoldRepository.trySeatHold(
 				trainScheduleId,
 				seatIds.get(0),
 				"new-pending",

--- a/src/test/java/com/sudo/raillo/booking/infrastructure/SeatHoldRepositoryTest.java
+++ b/src/test/java/com/sudo/raillo/booking/infrastructure/SeatHoldRepositoryTest.java
@@ -29,14 +29,14 @@ class SeatHoldRepositoryTest {
 	private static final Long TRAIN_SCHEDULE_ID = 1001L;
 	private static final Long SEAT_ID = 12L;
 	private static final Long TRAIN_CAR_ID = 231L;
-	private static final Duration HOLD_TTL = Duration.ofMinutes(10);
+	private static final Duration SEAT_HOLD_TTL = Duration.ofMinutes(10);
 
 	@Nested
-	@DisplayName("단일 좌석 Hold")
+	@DisplayName("단일 좌석 Seat Hold")
 	class SingleSeatHoldTest {
 
 		@Test
-		@DisplayName("충돌이 없는 구간은 Hold에 성공한다")
+		@DisplayName("충돌이 없는 구간은 Seat Hold에 성공한다")
 		void hold_success_when_no_conflict() {
 			// given
 			String pendingBookingId = "pending_001";
@@ -44,9 +44,9 @@ class SeatHoldRepositoryTest {
 			int arrivalStopOrder = 3;  // 구간: 0-1, 1-2, 2-3
 
 			// when
-			SeatHoldResult result = seatHoldRepository.tryHold(
+			SeatHoldResult result = seatHoldRepository.trySeatHold(
 				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId,
-				departureStopOrder, arrivalStopOrder, TRAIN_CAR_ID, HOLD_TTL
+				departureStopOrder, arrivalStopOrder, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			// then
@@ -55,18 +55,18 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("겹치지 않는 구간은 서로 Hold가 가능하다")
+		@DisplayName("겹치지 않는 구간은 서로 Seat Hold가 가능하다")
 		void hold_success_when_non_overlapping_sections() {
 			// given
 			String pendingBookingId1 = "pending_001";
 			String pendingBookingId2 = "pending_002";
 
 			// 첫 번째 Hold: 0-1, 1-2 구간
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 2, TRAIN_CAR_ID, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 2, TRAIN_CAR_ID, SEAT_HOLD_TTL);
 
 			// when - 두 번째 Hold: 2-3, 3-4 구간 (겹치지 않음)
-			SeatHoldResult result = seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 2, 4, TRAIN_CAR_ID, HOLD_TTL
+			SeatHoldResult result = seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 2, 4, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			// then
@@ -74,18 +74,18 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("기존 Hold와 겹치는 구간은 충돌이 발생한다")
+		@DisplayName("기존 Seat Hold와 겹치는 구간은 충돌이 발생한다")
 		void hold_fail_when_conflict_with_existing_hold() {
 			// given
 			String pendingBookingId1 = "pending_001";
 			String pendingBookingId2 = "pending_002";
 
 			// 첫 번째 Hold: 0-1, 1-2, 2-3 구간
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 3, TRAIN_CAR_ID, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 3, TRAIN_CAR_ID, SEAT_HOLD_TTL);
 
 			// when - 두 번째 Hold: 2-3, 3-4 구간 (2-3 겹침)
-			SeatHoldResult result = seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 2, 4, TRAIN_CAR_ID, HOLD_TTL
+			SeatHoldResult result = seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 2, 4, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			// then
@@ -95,36 +95,36 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("다양한 구간 길이에서 겹치는 구간은 Hold에 실패한다")
+		@DisplayName("다양한 구간 길이에서 겹치는 구간은 Seat Hold에 실패한다")
 		void various_section_lengths_conflict_test() {
 			// 1. 장거리 먼저 Hold (0-5)
-			SeatHoldResult result1 = seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_0", 0, 5, TRAIN_CAR_ID, HOLD_TTL
+			SeatHoldResult result1 = seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_0", 0, 5, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 			assertThat(result1.success()).isTrue();
 
 			// 2. 단거리 시도 - 겹침 (0-2)
-			SeatHoldResult result2 = seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_1", 0, 2, TRAIN_CAR_ID, HOLD_TTL
+			SeatHoldResult result2 = seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_1", 0, 2, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 			assertThat(result2.success()).isFalse();
 			assertThat(result2.isConflictWithHold()).isTrue();
 
 			// 3. 단거리 시도 - 겹침 (3-4)
-			SeatHoldResult result3 = seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_2", 3, 4, TRAIN_CAR_ID, HOLD_TTL
+			SeatHoldResult result3 = seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_2", 3, 4, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 			assertThat(result3.success()).isFalse();
 
 			// 4. 독립 구간 - 성공 (5-10)
-			SeatHoldResult result4 = seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_3", 5, 10, TRAIN_CAR_ID, HOLD_TTL
+			SeatHoldResult result4 = seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_3", 5, 10, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 			assertThat(result4.success()).isTrue();
 
 			// 5. 단거리 시도 - 겹침 (7-8)
-			SeatHoldResult result5 = seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_4", 7, 8, TRAIN_CAR_ID, HOLD_TTL
+			SeatHoldResult result5 = seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, "pending_4", 7, 8, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 			assertThat(result5.success()).isFalse();
 		}
@@ -134,22 +134,22 @@ class SeatHoldRepositoryTest {
 	@DisplayName("Confirm & Release")
 	class ConfirmAndReleaseTest {
 		@Test
-		@DisplayName("Hold 해제 후 같은 구간을 다시 Hold 할 수 있다")
+		@DisplayName("Seat Hold 해제 후 같은 구간을 다시 Seat Hold 할 수 있다")
 		void release_then_hold_again_success() {
 			// given
 			String pendingBookingId1 = "pending_001";
 			String pendingBookingId2 = "pending_002";
 
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 3, TRAIN_CAR_ID, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 3, TRAIN_CAR_ID, SEAT_HOLD_TTL);
 
 			// when
-			seatHoldRepository.releaseHold(
+			seatHoldRepository.releaseSeatHold(
 				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, TRAIN_CAR_ID, 0, 3
 			);
 
 			// then
-			SeatHoldResult result = seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 0, 3, TRAIN_CAR_ID, HOLD_TTL
+			SeatHoldResult result = seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 0, 3, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 			assertThat(result.success()).isTrue();
 		}
@@ -160,7 +160,7 @@ class SeatHoldRepositoryTest {
 	class ConcurrencyTest {
 
 		@Test
-		@DisplayName("100명이 동시에 같은 좌석 같은 구간 Hold 시도 시 1명만 성공한다")
+		@DisplayName("100명이 동시에 같은 좌석 같은 구간 Seat Hold 시도 시 1명만 성공한다")
 		void concurrent_hold_same_seat_same_section() throws InterruptedException {
 			// given
 			int numberOfThreads = 100;
@@ -181,8 +181,8 @@ class SeatHoldRepositoryTest {
 						readyLatch.countDown();		// 스레드 준비 완료 알림
 						startLatch.await();			// 모든 스레드가 여기서 대기, 동시에 출발
 
-						SeatHoldResult result = seatHoldRepository.tryHold(
-							TRAIN_SCHEDULE_ID, SEAT_ID, "pending_" + index, 0, 3, TRAIN_CAR_ID, HOLD_TTL
+						SeatHoldResult result = seatHoldRepository.trySeatHold(
+							TRAIN_SCHEDULE_ID, SEAT_ID, "pending_" + index, 0, 3, TRAIN_CAR_ID, SEAT_HOLD_TTL
 						);
 
 						if (result.success()) {
@@ -209,7 +209,7 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("10명이 동시에 같은 좌석 다른 구간 Hold 시도 시 겹치지 않으면 모두 성공한다")
+		@DisplayName("10명이 동시에 같은 좌석 다른 구간 Seat Hold 시도 시 겹치지 않으면 모두 성공한다")
 		void concurrent_hold_same_seat_different_sections() throws InterruptedException {
 			// given
 			int numberOfThreads = 10;
@@ -227,8 +227,8 @@ class SeatHoldRepositoryTest {
 						readyLatch.countDown();
 						startLatch.await();
 
-						SeatHoldResult result = seatHoldRepository.tryHold(
-							TRAIN_SCHEDULE_ID, SEAT_ID, "pending_" + index, index, index + 1, TRAIN_CAR_ID, HOLD_TTL
+						SeatHoldResult result = seatHoldRepository.trySeatHold(
+							TRAIN_SCHEDULE_ID, SEAT_ID, "pending_" + index, index, index + 1, TRAIN_CAR_ID, SEAT_HOLD_TTL
 						);
 						if (result.success()) {
 							successCount.incrementAndGet();
@@ -252,11 +252,11 @@ class SeatHoldRepositoryTest {
 	}
 
 	@Nested
-	@DisplayName("Hold Index 검증")
+	@DisplayName("TrainCar Hold Index 검증")
 	class HoldIndexTest {
 
 		@Test
-		@DisplayName("Hold 성공 시 Hold Index에 각 구간별 데이터가 추가된다")
+		@DisplayName("Seat Hold 성공 시 TrainCar Hold Index에 각 구간별 데이터가 추가된다")
 		void hold_success_creates_hold_index_entries() {
 			// given
 			String pendingBookingId = "pending_001";
@@ -265,8 +265,8 @@ class SeatHoldRepositoryTest {
 			String trainCarHoldIndexKey = "{schedule:1001}:traincar:231:holding-seats";
 
 			// when
-			seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId, departureStopOrder, arrivalStopOrder, TRAIN_CAR_ID, HOLD_TTL
+			seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId, departureStopOrder, arrivalStopOrder, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			// then
@@ -278,7 +278,7 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("Release 시 Hold Index에서 해당 구간 데이터가 제거된다")
+		@DisplayName("Release 시 TrainCar Hold Index에서 해당 구간 데이터가 제거된다")
 		void release_removes_hold_index_entries() {
 			// given
 			String pendingBookingId = "pending_001";
@@ -287,13 +287,13 @@ class SeatHoldRepositoryTest {
 			String trainCarHoldIndexKey = "{schedule:1001}:traincar:231:holding-seats";
 
 			// Hold 먼저 수행
-			seatHoldRepository.tryHold(
+			seatHoldRepository.trySeatHold(
 				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId,
-				departureStopOrder, arrivalStopOrder, TRAIN_CAR_ID, HOLD_TTL
+				departureStopOrder, arrivalStopOrder, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			// when
-			seatHoldRepository.releaseHold(
+			seatHoldRepository.releaseSeatHold(
 				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId,
 				TRAIN_CAR_ID, departureStopOrder, arrivalStopOrder
 			);
@@ -304,7 +304,7 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("같은 좌석의 서로 다른 구간 Hold 시 Hold Index에 모두 추가된다")
+		@DisplayName("같은 좌석의 서로 다른 구간 Seat Hold 시 TrainCar Hold Index에 모두 추가된다")
 		void different_sections_create_separate_hold_index_entries() {
 			// given
 			String pendingBookingId1 = "pending_001";
@@ -312,13 +312,13 @@ class SeatHoldRepositoryTest {
 			String trainCarHoldIndexKey = "{schedule:1001}:traincar:231:holding-seats";
 
 			// when - 첫 번째 사용자: 구간 0-1
-			seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 1, TRAIN_CAR_ID, HOLD_TTL
+			seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 1, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			// 두 번째 사용자: 구간 2-3 (겹치지 않음)
-			seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 2, 3, TRAIN_CAR_ID, HOLD_TTL
+			seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 2, 3, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			// then
@@ -329,7 +329,7 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("Hold Index의 score는 만료 시간으로 설정된다")
+		@DisplayName("TrainCar Hold Index의 score는 만료 시간으로 설정된다")
 		void hold_index_score_is_expiry_time() {
 			// given
 			String pendingBookingId = "pending_001";
@@ -337,8 +337,8 @@ class SeatHoldRepositoryTest {
 			long beforeHold = System.currentTimeMillis() / 1000; // 초 단위로 변환
 
 			// when
-			seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId, 0, 1, TRAIN_CAR_ID, HOLD_TTL
+			seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId, 0, 1, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			long afterHold = System.currentTimeMillis() / 1000; // 초 단위로 변환
@@ -353,15 +353,15 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("Hold Index의 TTL은 Hold TTL의 2배로 설정된다")
+		@DisplayName("TrainCar Hold Index의 TTL은 Seat Hold TTL의 2배로 설정된다")
 		void hold_index_ttl_is_double_of_hold_ttl() {
 			// given
 			String pendingBookingId = "pending_001";
 			String trainCarHoldIndexKey = "{schedule:1001}:traincar:231:holding-seats";
 
 			// when
-			seatHoldRepository.tryHold(
-				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId, 0, 1, TRAIN_CAR_ID, HOLD_TTL
+			seatHoldRepository.trySeatHold(
+				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId, 0, 1, TRAIN_CAR_ID, SEAT_HOLD_TTL
 			);
 
 			// then
@@ -371,18 +371,18 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("부분 Release 시 Hold Index에서 해당 구간만 제거된다")
+		@DisplayName("부분 Release 시 TrainCar Hold Index에서 해당 구간만 제거된다")
 		void partial_release_removes_only_released_sections() {
 			// given
 			String pendingBookingId1 = "pending_001";
 			String pendingBookingId2 = "pending_002";
 			String trainCarHoldIndexKey = "{schedule:1001}:traincar:231:holding-seats";
 
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 1, TRAIN_CAR_ID, HOLD_TTL);
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 2, 3, TRAIN_CAR_ID, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, 0, 1, TRAIN_CAR_ID, SEAT_HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId2, 2, 3, TRAIN_CAR_ID, SEAT_HOLD_TTL);
 
 			// when
-			seatHoldRepository.releaseHold(
+			seatHoldRepository.releaseSeatHold(
 				TRAIN_SCHEDULE_ID, SEAT_ID, pendingBookingId1, TRAIN_CAR_ID, 0, 1
 			);
 
@@ -395,11 +395,11 @@ class SeatHoldRepositoryTest {
 	}
 
 	@Nested
-	@DisplayName("Hold 점유 수 조회 테스트")
+	@DisplayName("Seat Hold 점유 수 조회 테스트")
 	class GetHoldSeatsCountTest {
 
 		@Test
-		@DisplayName("Hold가 없으면 Hold 점유 수가 0이다")
+		@DisplayName("Seat Hold가 없으면 Seat Hold 점유 수가 0이다")
 		void getHoldSeatsCount_returns_zero_when_no_holds() {
 			// when
 			int count = seatHoldRepository.getHoldSeatsCount(
@@ -411,10 +411,10 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("Hold된 좌석의 겹치는 구간만 점유 수에 포함된다")
+		@DisplayName("Seat Hold된 좌석의 겹치는 구간만 점유 수에 포함된다")
 		void getHoldSeatsCount_counts_only_overlapping_sections() {
 			// given
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 1, 3, TRAIN_CAR_ID, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 1, 3, TRAIN_CAR_ID, SEAT_HOLD_TTL);
 
 			// when
 			int count = seatHoldRepository.getHoldSeatsCount(
@@ -426,10 +426,10 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("겹치지 않는 구간의 Hold는 점유 수에 포함되지 않는다")
+		@DisplayName("겹치지 않는 구간의 Seat Hold는 점유 수에 포함되지 않는다")
 		void getHoldSeatsCount_excludes_non_overlapping_sections() {
 			// given
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 0, 1, TRAIN_CAR_ID, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 0, 1, TRAIN_CAR_ID, SEAT_HOLD_TTL);
 
 			// when
 			int count = seatHoldRepository.getHoldSeatsCount(
@@ -441,10 +441,10 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("같은 좌석이 여러 구간에 Hold되어도 좌석 수는 1이다")
+		@DisplayName("같은 좌석이 여러 구간에 Seat Hold되어도 좌석 수는 1이다")
 		void getHoldSeatsCount_deduplicates_same_seat() {
 			// given
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 0, 3, TRAIN_CAR_ID, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 0, 3, TRAIN_CAR_ID, SEAT_HOLD_TTL);
 
 			// when
 			int count = seatHoldRepository.getHoldSeatsCount(
@@ -456,12 +456,12 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("여러 좌석이 Hold되면 좌석 수만큼 카운트된다")
+		@DisplayName("여러 좌석이 Seat Hold되면 좌석 수만큼 카운트된다")
 		void getHoldSeatsCount_counts_multiple_seats() {
 			// given
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 0, 2, TRAIN_CAR_ID, HOLD_TTL);
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, 13L, "pending_001", 0, 2, TRAIN_CAR_ID, HOLD_TTL);
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, 14L, "pending_001", 0, 2, TRAIN_CAR_ID, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 0, 2, TRAIN_CAR_ID, SEAT_HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, 13L, "pending_001", 0, 2, TRAIN_CAR_ID, SEAT_HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, 14L, "pending_001", 0, 2, TRAIN_CAR_ID, SEAT_HOLD_TTL);
 
 			// when
 			int count = seatHoldRepository.getHoldSeatsCount(
@@ -473,11 +473,11 @@ class SeatHoldRepositoryTest {
 		}
 
 		@Test
-		@DisplayName("여러 객차의 Hold를 한 번에 조회하여 합산한다")
+		@DisplayName("여러 객차의 Seat Hold를 한 번에 조회하여 합산한다")
 		void getHoldSeatsCount_aggregates_multiple_train_cars() {
 			// given
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 0, 2, TRAIN_CAR_ID, HOLD_TTL);
-			seatHoldRepository.tryHold(TRAIN_SCHEDULE_ID, 13L, "pending_002", 0, 2, 234L, HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, SEAT_ID, "pending_001", 0, 2, TRAIN_CAR_ID, SEAT_HOLD_TTL);
+			seatHoldRepository.trySeatHold(TRAIN_SCHEDULE_ID, 13L, "pending_002", 0, 2, 234L, SEAT_HOLD_TTL);
 
 			// when
 			int count = seatHoldRepository.getHoldSeatsCount(

--- a/src/test/java/com/sudo/raillo/payment/application/PaymentFacadeConfirmTest.java
+++ b/src/test/java/com/sudo/raillo/payment/application/PaymentFacadeConfirmTest.java
@@ -211,7 +211,7 @@ class PaymentFacadeConfirmTest {
 	}
 
 	@Test
-	@DisplayName("결제 승인 성공 시 좌석 Hold가 해제된다")
+	@DisplayName("결제 승인 성공 시 Seat Hold가 해제된다")
 	void confirmPayment_holdReleasedAfterSuccess() {
 		// given
 		BigDecimal amount = BigDecimal.valueOf(50000);
@@ -240,7 +240,7 @@ class PaymentFacadeConfirmTest {
 		Long trainCarId = trainTestHelper.getSeats(
 			trainScheduleResult.trainSchedule().getTrain(), CarType.STANDARD, 1
 			).get(0).getTrainCar().getId();
-		SeatHoldResult result = seatHoldRepository.tryHold(
+		SeatHoldResult result = seatHoldRepository.trySeatHold(
 			trainScheduleResult.trainSchedule().getId(),
 			seatId,
 			"other-pending-booking",
@@ -383,7 +383,7 @@ class PaymentFacadeConfirmTest {
 			.withTotalFare(fare)
 			.build();
 
-		// 실제 플로우처럼 좌석 Hold 먼저 설정 (PendingBookingFacade가 하는 일)
+		// 실제 플로우처럼 Seat Hold 먼저 설정 (PendingBookingFacade가 하는 일)
 		seatHoldService.holdSeats(
 			pendingBooking.getId(),
 			trainScheduleResult.trainSchedule().getId(),

--- a/src/test/java/com/sudo/raillo/payment/application/PaymentScenarioTest.java
+++ b/src/test/java/com/sudo/raillo/payment/application/PaymentScenarioTest.java
@@ -271,7 +271,7 @@ class PaymentScenarioTest {
 
 		Long trainCarId = seats.get(0).getTrainCar().getId();
 
-		// 좌석 Hold
+		// Seat Hold
 		seatHoldService.holdSeats(pb1.getId(), trainScheduleResult.trainSchedule().getId(),
 			departureStop, arrivalStop, List.of(seatIds.get(0)), trainCarId, Duration.ofMinutes(10));
 		seatHoldService.holdSeats(pb2.getId(), trainScheduleResult.trainSchedule().getId(),

--- a/src/test/java/com/sudo/raillo/train/application/calculator/SeatAvailabilityCalculatorTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/calculator/SeatAvailabilityCalculatorTest.java
@@ -189,7 +189,7 @@ class SeatAvailabilityCalculatorTest {
 	}
 
 	@Test
-	@DisplayName("Hold 점유가 있으면 잔여석에서 차감된다")
+	@DisplayName("Seat Hold 점유가 있으면 잔여석에서 차감된다")
 	void holdSeatsReduceRemaining() {
 		// given
 		Map<CarType, Integer> totalSeats = Map.of(

--- a/src/test/java/com/sudo/raillo/train/application/facade/TrainSearchFacadeCarAndSeatTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/facade/TrainSearchFacadeCarAndSeatTest.java
@@ -223,7 +223,7 @@ public class TrainSearchFacadeCarAndSeatTest {
 			.toList();
 	}
 
-	@DisplayName("Hold가 있는 경우 객차 잔여석에서 차감된다")
+	@DisplayName("Seat Hold가 있는 경우 객차 잔여석에서 차감된다")
 	@Test
 	void getAvailableTrainCars_hold_reduces_remaining_seats() {
 		// given
@@ -259,7 +259,7 @@ public class TrainSearchFacadeCarAndSeatTest {
 		assertThat(totalRemainingSeats).isEqualTo(94);
 	}
 
-	@DisplayName("Hold 차감 후 잔여석이 0인 객차는 목록에서 제외된다")
+	@DisplayName("Seat Hold 차감 후 잔여석이 0인 객차는 목록에서 제외된다")
 	@Test
 	void getAvailableTrainCars_filters_out_zero_remaining_cars_due_to_hold() {
 		// given
@@ -301,7 +301,7 @@ public class TrainSearchFacadeCarAndSeatTest {
 		assertThat(response.totalCarCount()).isEqualTo(1);
 	}
 
-	@DisplayName("Hold 차감 후 모든 객차의 잔여석이 0이면 NO_AVAILABLE_CARS 예외가 발생한다")
+	@DisplayName("Seat Hold 차감 후 모든 객차의 잔여석이 0이면 NO_AVAILABLE_CARS 예외가 발생한다")
 	@Test
 	void getAvailableTrainCars_throws_when_all_cars_exhausted_by_hold() {
 		// given
@@ -333,7 +333,7 @@ public class TrainSearchFacadeCarAndSeatTest {
 			.hasMessageContaining(TrainErrorCode.NO_AVAILABLE_CARS.getMessage());
 	}
 
-	@DisplayName("SeatBooking과 Hold가 함께 존재하면 둘 다 차감된다")
+	@DisplayName("SeatBooking과 Seat Hold가 함께 존재하면 둘 다 차감된다")
 	@Test
 	void getAvailableTrainCars_deducts_seatBooking_and_hold_together() {
 		// given
@@ -432,7 +432,7 @@ public class TrainSearchFacadeCarAndSeatTest {
 		int arrivalStopOrder = arrivalStop.getStopOrder();
 
 		seats.forEach(seat -> assertThat(
-			seatHoldRepository.tryHold(
+			seatHoldRepository.trySeatHold(
 				trainScheduleId,
 				seat.getId(),
 				pendingBookingId,

--- a/src/test/java/com/sudo/raillo/train/application/facade/TrainSearchFacadeSeatCalculationTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/facade/TrainSearchFacadeSeatCalculationTest.java
@@ -60,7 +60,7 @@ class TrainSearchFacadeSeatCalculationTest {
 	private RedisTemplate<String, String> customStringRedisTemplate;
 
 	@Test
-	@DisplayName("SeatBooking과 Hold가 모두 잔여석에 반영된다")
+	@DisplayName("SeatBooking과 Seat Hold가 모두 잔여석에 반영된다")
 	void searchTrains_reflects_both_seatBooking_and_hold() {
 		// given
 		LocalDate searchDate = LocalDate.now().plusDays(1);
@@ -92,7 +92,7 @@ class TrainSearchFacadeSeatCalculationTest {
 			.addSeats(standardSeats, PassengerType.ADULT)
 			.build();
 
-		// Hold: 일반실 5석, 특실 3석 임시 점유
+		// Seat Hold: 일반실 5석, 특실 3석
 		List<Seat> holdStandardSeats = trainTestHelper.getAvailableSeats(
 			scheduleResult.trainSchedule(), CarType.STANDARD, 5);
 		List<Seat> holdFirstClassSeats = trainTestHelper.getAvailableSeats(
@@ -119,7 +119,7 @@ class TrainSearchFacadeSeatCalculationTest {
 	}
 
 	@Test
-	@DisplayName("Hold만 있는 경우에도 잔여석에 반영된다")
+	@DisplayName("Seat Hold만 있는 경우에도 잔여석에 반영된다")
 	void searchTrains_reflects_hold_only() {
 		// given
 		LocalDate searchDate = LocalDate.now().plusDays(1);
@@ -141,7 +141,7 @@ class TrainSearchFacadeSeatCalculationTest {
 		ScheduleStop arrivalStop = trainScheduleTestHelper.getScheduleStopByStationName(scheduleResult, "부산");
 		Long trainScheduleId = scheduleResult.trainSchedule().getId();
 
-		// Hold: 일반실 8석 임시 점유
+		// Seat Hold: 일반실 8석
 		List<Seat> holdStandardSeats = trainTestHelper.getSeats(train, CarType.STANDARD, 8);
 		holdSeats(holdStandardSeats, trainScheduleId, departureStop, arrivalStop);
 
@@ -163,7 +163,7 @@ class TrainSearchFacadeSeatCalculationTest {
 	}
 
 	@Test
-	@DisplayName("SeatBooking과 Hold 합산으로 인원 수용이 불가능하면 예약 불가로 판단한다")
+	@DisplayName("SeatBooking과 Seat Hold 합산으로 인원 수용이 불가능하면 예약 불가로 판단한다")
 	void searchTrains_not_reservable_when_combined_insufficient() {
 		// given
 		LocalDate searchDate = LocalDate.now().plusDays(1);
@@ -214,7 +214,7 @@ class TrainSearchFacadeSeatCalculationTest {
 	}
 
 	@Test
-	@DisplayName("Hold 구간이 검색 구간과 겹치지 않으면 잔여석에 반영되지 않는다")
+	@DisplayName("Seat Hold 구간이 검색 구간과 겹치지 않으면 잔여석에 반영되지 않는다")
 	void searchTrains_hold_non_overlapping_section_not_counted() {
 		// given
 		LocalDate searchDate = LocalDate.now().plusDays(1);
@@ -256,7 +256,7 @@ class TrainSearchFacadeSeatCalculationTest {
 	}
 
 	@Test
-	@DisplayName("Hold 구간이 검색 구간과 겹치면 잔여석에 반영된다")
+	@DisplayName("Seat Hold 구간이 검색 구간과 겹치면 잔여석에 반영된다")
 	void searchTrains_hold_overlapping_section_is_counted() {
 		// given
 		LocalDate searchDate = LocalDate.now().plusDays(1);
@@ -297,7 +297,7 @@ class TrainSearchFacadeSeatCalculationTest {
 	}
 
 	@Test
-	@DisplayName("만료된 Hold는 잔여석에 반영되지 않는다")
+	@DisplayName("만료된 Seat Hold는 잔여석에 반영되지 않는다")
 	void searchTrains_expired_hold_not_counted() {
 		// given
 		LocalDate searchDate = LocalDate.now().plusDays(1);
@@ -358,7 +358,7 @@ class TrainSearchFacadeSeatCalculationTest {
 		int departureStopOrder = departureStop.getStopOrder();
 		int arrivalStopOrder = arrivalStop.getStopOrder();
 
-		seats.forEach(seat -> seatHoldRepository.tryHold(
+		seats.forEach(seat -> seatHoldRepository.trySeatHold(
 			trainScheduleId,
 			seat.getId(),
 			pendingBookingId,


### PR DESCRIPTION
<!-- 2025. 06. 28. PR 템플릿 -->
<!-- 이것은 주석입니다. -->
<!-- PR 제목은 연관되어있는 Issue의 제목과 동일하게 작성해주세요. -->
<!-- 아래 '관련 Issue'를 작성하고 Preview 모드로 전환한 뒤 제목을 작성하면 편합니다. -->

## 관련 Issue (필수)
<!-- 어떤 Issue를 해결하는지 입력해주세요, 한 줄에 하나의 Issue만 입력할 수 있습니다. -->
- close #163 

## 주요 변경 사항 (필수)
- Redis Cluster CROSSSLOT 방지를 위해 Hold/Holds 키의 해시태그를 
`{seat:scheduleId:seatId}` -> `{schedule:scheduleId}`로 통일
- Seat Hold 관련 상수, 메서드, 변수 네이밍 개선


## 리뷰어 참고 사항
<!-- 리뷰 시 참고할 점들을 자유로운 형식으로 작성해주세요. -->
주석과 변수명만 변경되었고 실행 로직은 변경 없습니다.
```diff
-  private static final String SEAT_HOLD_KEY_FORMAT = "{seat:%d:%d}:hold:%s";
-  private static final String SEAT_HOLDS_KEY_FORMAT = "{seat:%d:%d}:holds";
+  private static final String SEAT_HOLD_KEY_FORMAT = "{schedule:%d}:seat:%d:hold:%s";
+  private static final String SEAT_HOLD_INDEX_KEY_FORMAT = "{schedule:%d}:seat:%d:holds";
```
변수명은 아래와 같이 변경했는데 혹시 생각하신 다른 변수명 있으시면 말씀해주세요!
```diff
- private static final String SEAT_HOLD_KEY_FORMAT // 점유 데이터
- private static final String SEAT_HOLDS_KEY_FORMAT // 좌석별 인덱스
- private static final String HOLD_INDEX_KEY_FORMAT // 객차별 인덱스
+ private static final String SEAT_HOLD_KEY_FORMAT // 그대로
+ private static final String SEAT_HOLD_INDEX_KEY_FORMAT // 좌석 단위 인덱스
+ private static final String TRAINCAR_HOLD_INDEX_KEY_FORMAT // 객차 단위 인덱스
```
## 추가 정보
<!-- PR과 관련된 추가 정보가 있다면 자유롭게 작성해주세요. -->
없음

## PR 작성 체크리스트 (필수)
<!-- 각 항목을 확인하고 '[ ]'를 '[x]'로 체크해주세요. -->
- [x] 제목이 Issue와 동일함을 확인했습니다.
