### PR TITLE
[CHORE] 테스트 DB Docker 이미지 레지스트리 변경

### DIFF
--- a/compose-test.yaml
+++ b/compose-test.yaml
@@ -30,7 +30,7 @@ services:
           memory: 1G # application server 메모리 용량
 
   mysql:
-    image: 'chanwon2/raillo-test-db:latest'
+    image: 'ogu1208/raillo-test-db:latest'
     environment:
       - 'MYSQL_DATABASE=raillo'
       - 'MYSQL_PASSWORD=secret'


### PR DESCRIPTION
## 관련 Issue (필수)
- close #197

## 주요 변경 사항 (필수)
- `compose-test.yaml`의 테스트 DB 이미지를 `ogu1208/raillo-test-db:latest`로 변경
- [raillo-batch PR](https://github.com/penggu-dev/raillo-batch/pull/1)에서 테스트 DB 이미지 빌드 파이프라인을 `ogu1208` Docker Hub 레지스트리로 이전함에 따라, 본 프로젝트도 동일하게 반영

## 리뷰어 참고 사항
없음

## 추가 정보
- 관련 PR: https://github.com/penggu-dev/raillo-batch/pull/1

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.