### PR TITLE
[CHORE] Pod 분산 배치를 위한 topologySpreadConstraints 설정

### DIFF
--- a/k8s/k8s-application/depl_svc.yml
+++ b/k8s/k8s-application/depl_svc.yml
@@ -22,6 +22,12 @@ spec:
           labelSelector:
             matchLabels:
               app: raillo-backend
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: raillo-backend
       containers:
         - name: raillo-backend
           image: 052104148083.dkr.ecr.ap-northeast-2.amazonaws.com/raillo-backend:latest


### PR DESCRIPTION
## 관련 Issue (필수)
- close #207

## 주요 변경 사항 (필수)
- Deployment에 `topologySpreadConstraints` 설정을 추가하여 `raillo-backend` Pod가 노드 간, AZ 간 분산 배치되도록 유도
- 동일 노드에 레플리카가 집중되어 부하테스트 시 CPU hotspot이 발생하고, 노드 장애 시 전체 서비스가 중단될 수 있는 문제를 해결

| 설정 항목 | 값 | 설명 |
|-----------|-----|------|
| `maxSkew` | 1 | 노드/AZ 간 Pod 수 차이를 최대 1로 제한 |
| `topologyKey` (1) | `kubernetes.io/hostname` | 노드 단위로 분산 |
| `topologyKey` (2) | `topology.kubernetes.io/zone` | AZ 단위로 분산 |
| `whenUnsatisfiable` | `ScheduleAnyway` | 분산 불가 시에도 Pod를 스케줄링하여 가용성 우선 |

## 리뷰어 참고 사항

### `podAntiAffinity` 대신 `topologySpreadConstraints`를 선택한 이유

기존에도 쿠버네티스에는 유사한 문제를 해결하기 위해 Affinity/AntiAffinity를 제공하고 있습니다. 그러나 이 기능은 Pod를 원하는 노드에 배치하는 데 있어서 일부적인 해결일 뿐, Pod를 적절하게 분산시켜서 스케줄링해준다고는 말하기 어렵습니다.

- `podAntiAffinity`는 "같은 노드에 두지 마라"라는 **배제 규칙**이지, 노드 간 균등 분산을 보장하지 않음
- 노드가 3개 이상일 때 레플리카 4개를 띄우면 AntiAffinity만으로는 2-2-0 같은 불균형 배치가 발생할 수 있음
- `topologySpreadConstraints`는 `maxSkew`를 통해 노드 간 Pod 수 차이를 직접 제어하므로 **균등 분산 의도를 명확하게 표현**할 수 있음

### `ScheduleAnyway`를 선택한 이유

- `ScheduleAnyway`(preferred 강도): 노드 부족/장애 상황에서도 Pod가 Pending 없이 떠서 서비스 가용성이 유지됨
- `DoNotSchedule`(required 강도): 분산 불가 시 Pod가 Pending 상태로 방치되어 스케일아웃이 막힐 수 있음

### AZ 분산을 추가한 이유

- 노드 단위 분산만으로는 같은 AZ에 모든 Pod가 몰릴 수 있음
- AZ 전체 장애 시 서비스가 중단되는 것을 방지하기 위해 `topology.kubernetes.io/zone` 기준 분산도 함께 적용

## 추가 정보
- 추후 HPA + Cluster Autoscaler/Karpenter 도입 검토 예정 (이슈 #207 2차 항목)

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.