### PR TITLE
[REFACTOR] ErrorCode 네이밍·코드 체계 일관성 개선 및 중복 정리

### DIFF
--- a/.claude/skills/validator/SKILL.md
+++ b/.claude/skills/validator/SKILL.md
@@ -160,5 +160,5 @@ public void validatePaymentKeyUnique(String paymentKey) {
 
 {ERROR_CODE}("{메시지}", HttpStatus.{STATUS}, "{prefix}_{번호}")
 
-예: PASSENGER_SEAT_MISMATCH("승객 수와 좌석 수가 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "B_007")
+예: PASSENGER_SEAT_MISMATCH("승객 수와 좌석 수가 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "BOOKING_108")
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,9 +64,11 @@ Controller → Facade → Service → Repository
 도메인별 에러 enum은 `ErrorCode`를 구현한다:
 ```java
 public enum BookingError implements ErrorCode {
-    SEAT_NOT_FOUND("좌석을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_001");
+    BOOKING_NOT_FOUND("예매 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "BOOKING_101");
 }
 ```
+
+> 코드 형식·접두사·밴드·추가 절차 → [docs/error-code-convention.md](./docs/error-code-convention.md)
 
 **Validator Pattern** — `@Component`로 `application/validator/`에 `{Domain}Validator` 작성. Service/Facade에 주입되어 실패 시 `BusinessException`을 던진다.
 
@@ -172,6 +174,9 @@ Java 17, Spring Boot 3.5.0, MySQL (prod/dev), H2 (test), Redis, QueryDSL 5.0.0 (
 
 - **좌석 충돌 검증 로직 변경 시** → [docs/seat-conflict-validation.md](./docs/seat-conflict-validation.md)
   핵심: 4-Layer 방어 (Lua → SQL Fail Fast → SQL Re-validation → TTL Expiry) 영향 범위 모두 검토.
+
+- **에러 코드 추가/변경 시** → [docs/error-code-convention.md](./docs/error-code-convention.md)
+  핵심: `{DOMAIN}_{NNN}` 형식, 도메인별 카테고리 밴드(백의 자리), 새 코드 추가 절차.
 
 - **새 도메인/엔티티 추가, Booking Flow 이해 시** → [docs/domain-model.md](./docs/domain-model.md)
   핵심: 엔티티 관계도, Status enum, 한국어 용어(예약/예매/승차권) 일관 사용.

--- a/docs/error-code-convention.md
+++ b/docs/error-code-convention.md
@@ -1,0 +1,52 @@
+# 에러 코드 컨벤션
+
+raillo 백엔드의 모든 도메인 `ErrorCode` enum이 따르는 규칙. 새 에러 코드를 추가하거나 변경할 때 이 문서를 따른다.
+
+## 형식
+
+`{DOMAIN}_{NNN}`
+
+- `{DOMAIN}`: 도메인 패키지명 풀워드(대문자). 아래 접두사 맵 참고.
+- 구분자: 언더스코어 1개.
+- `{NNN}`: 3자리 숫자. 백의 자리 = 카테고리(밴드).
+
+예: `BOOKING_101`, `TRAIN_203`, `PAYMENT_901`.
+
+## 접두사 맵
+
+| 도메인 / Enum | 접두사 |
+|---------------|--------|
+| auth / `AuthError` | `AUTH_` |
+| auth / `TokenError` | `TOKEN_` |
+| member / `MemberError` | `MEMBER_` |
+| booking / `BookingError` | `BOOKING_` |
+| train / `TrainError` | `TRAIN_` |
+| order / `OrderError` | `ORDER_` |
+| payment / `PaymentError` | `PAYMENT_` |
+| redis / `RedisError` | `REDIS_` |
+| global / `GlobalError` | `GLOBAL_` |
+
+enum 클래스명은 `{Domain}Error` 형식으로 통일한다.
+
+## 카테고리 밴드 (백의 자리)
+
+에러가 많은 대형 도메인은 백의 자리로 카테고리를 구분한다.
+
+| 도메인 | 1xx | 2xx | 3xx | 4xx | 5xx | 9xx |
+|--------|-----|-----|-----|-----|-----|-----|
+| `BOOKING_` | 예매/좌석예약 | 승차권 | 임시예약 | 좌석점유·충돌 | 영수증 | — |
+| `TRAIN_` | 열차/스케줄 | 객차/좌석 | 역/구간/운임 | 날짜/검색 | — | — |
+| `PAYMENT_` | 결제 상태 | 금액/수단/키 | — | — | — | 시스템 |
+| `GLOBAL_` | 클라이언트(0xx) | — | — | — | 서버(5xx) | — |
+
+소형 도메인(`AUTH_`, `TOKEN_`, `MEMBER_`, `ORDER_`, `REDIS_`)은 카테고리가 단일하므로 밴드 없이 `001`부터 평면 순번을 쓴다.
+
+## 새 에러 코드 추가 절차
+
+1. 에러가 속한 **도메인 enum**을 고른다(접두사 맵).
+2. 대형 도메인이면 해당하는 **밴드(백의 자리)** 를 정한다.
+3. 그 밴드(또는 평면) 내에서 **다음 번호**를 부여한다.
+4. `("메시지", HttpStatus.XXX, "{DOMAIN}_{NNN}")` 형식으로 상수를 추가한다.
+5. 도메인 enum은 `ErrorCode` 인터페이스를 구현한다(`getMessage`/`getStatus`/`getCode`).
+
+예) 승차권 관련 새 에러 → `BookingError`의 2xx 밴드 → 마지막이 `BOOKING_204`면 `BOOKING_205`.

--- a/src/main/java/com/sudo/raillo/auth/exception/AuthError.java
+++ b/src/main/java/com/sudo/raillo/auth/exception/AuthError.java
@@ -11,8 +11,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuthError implements ErrorCode {
 
-	SEND_EMAIL_FAIL("인증 이메일 전송이 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "E_001"),
-	INVALID_AUTH_CODE("인증 코드가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "E_002");
+	SEND_EMAIL_FAIL("인증 이메일 전송이 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_001"),
+	INVALID_AUTH_CODE("인증 코드가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "AUTH_002");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/auth/exception/TokenError.java
+++ b/src/main/java/com/sudo/raillo/auth/exception/TokenError.java
@@ -11,12 +11,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TokenError implements ErrorCode {
 
-	INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_002"),
-	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "T_004"),
-	INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_005"),
-	AUTHORITY_NOT_FOUND("권한 정보가 없는 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_006"),
-	NOT_EQUALS_REFRESH_TOKEN("리프레시 토큰이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_007"),
-	INVALID_TEMPORARY_TOKEN_USAGE("임시토큰으로 해당 요청에 접근할 수 없습니다.", HttpStatus.UNAUTHORIZED, "T_008");
+	INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED, "TOKEN_001"),
+	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "TOKEN_002"),
+	INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "TOKEN_003"),
+	AUTHORITY_NOT_FOUND("권한 정보가 없는 토큰입니다.", HttpStatus.UNAUTHORIZED, "TOKEN_004"),
+	NOT_EQUALS_REFRESH_TOKEN("리프레시 토큰이 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "TOKEN_005"),
+	INVALID_TEMPORARY_TOKEN_USAGE("임시토큰으로 해당 요청에 접근할 수 없습니다.", HttpStatus.UNAUTHORIZED, "TOKEN_006");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/auth/exception/TokenError.java
+++ b/src/main/java/com/sudo/raillo/auth/exception/TokenError.java
@@ -11,9 +11,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TokenError implements ErrorCode {
 
-	INVALID_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_001"),
 	INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_002"),
-	LOGOUT_ERROR("로그아웃: 토큰이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_003"),
 	ALREADY_LOGOUT("이미 로그아웃된 토큰입니다.", HttpStatus.FORBIDDEN, "T_004"),
 	INVALID_PASSWORD("비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED, "T_005"),
 	AUTHORITY_NOT_FOUND("권한 정보가 없는 토큰입니다.", HttpStatus.UNAUTHORIZED, "T_006"),

--- a/src/main/java/com/sudo/raillo/booking/application/service/BookingService.java
+++ b/src/main/java/com/sudo/raillo/booking/application/service/BookingService.java
@@ -36,7 +36,7 @@ import com.sudo.raillo.order.exception.OrderError;
 import com.sudo.raillo.order.infrastructure.OrderBookingRepository;
 import com.sudo.raillo.order.infrastructure.OrderSeatBookingRepository;
 import com.sudo.raillo.train.domain.Seat;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.SeatRepository;
 
 import jakarta.persistence.OptimisticLockException;
@@ -195,7 +195,7 @@ public class BookingService {
 	) {
 		Seat seat = seatMap.get(orderSeatBooking.getSeatId());
 		if (seat == null) {
-			throw new BusinessException(TrainErrorCode.SEAT_NOT_FOUND);
+			throw new BusinessException(TrainError.SEAT_NOT_FOUND);
 		}
 
 		SeatBooking seatBooking = SeatBooking.create(

--- a/src/main/java/com/sudo/raillo/booking/application/service/PendingBookingService.java
+++ b/src/main/java/com/sudo/raillo/booking/application/service/PendingBookingService.java
@@ -14,7 +14,7 @@ import com.sudo.raillo.global.exception.error.BusinessException;
 import com.sudo.raillo.train.domain.ScheduleStop;
 import com.sudo.raillo.train.domain.Seat;
 import com.sudo.raillo.train.domain.TrainSchedule;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.ScheduleStopRepository;
 import com.sudo.raillo.train.infrastructure.SeatRepository;
 import com.sudo.raillo.train.infrastructure.TrainScheduleRepository;
@@ -180,7 +180,7 @@ public class PendingBookingService {
 		List<TrainSchedule> trainSchedules = trainScheduleRepository.findAllByIdWithTrain(trainScheduleIds);
 
 		if (trainSchedules.size() != trainScheduleIds.size()) {
-			throw new BusinessException(TrainErrorCode.TRAIN_SCHEDULE_NOT_FOUND);
+			throw new BusinessException(TrainError.TRAIN_SCHEDULE_NOT_FOUND);
 		}
 
 		return trainSchedules.stream()
@@ -198,7 +198,7 @@ public class PendingBookingService {
 		List<ScheduleStop> scheduleStops = scheduleStopRepository.findAllByIdWithStation(stopIds);
 
 		if (scheduleStops.size() != stopIds.size()) {
-			throw new BusinessException(TrainErrorCode.STATION_NOT_FOUND);
+			throw new BusinessException(TrainError.STATION_NOT_FOUND);
 		}
 
 		return scheduleStops.stream()
@@ -216,7 +216,7 @@ public class PendingBookingService {
 		List<Seat> seats = seatRepository.findAllByIdWithTrainCar(seatIds);
 
 		if (seats.size() != seatIds.size()) {
-			throw new BusinessException(TrainErrorCode.SEAT_NOT_FOUND);
+			throw new BusinessException(TrainError.SEAT_NOT_FOUND);
 		}
 
 		return seats.stream()

--- a/src/main/java/com/sudo/raillo/booking/application/validator/BookingValidator.java
+++ b/src/main/java/com/sudo/raillo/booking/application/validator/BookingValidator.java
@@ -23,7 +23,7 @@ import com.sudo.raillo.train.domain.ScheduleStop;
 import com.sudo.raillo.train.domain.TrainSchedule;
 import com.sudo.raillo.train.domain.status.OperationStatus;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.ScheduleStopRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -53,7 +53,7 @@ public class BookingValidator {
 	 * */
 	public void validateSameSchedule(ScheduleStop departureStop, ScheduleStop arrivalStop) {
 		if (!departureStop.getTrainSchedule().getId().equals(arrivalStop.getTrainSchedule().getId())) {
-			throw new BusinessException(TrainErrorCode.INVALID_ROUTE);
+			throw new BusinessException(TrainError.INVALID_ROUTE);
 		}
 	}
 
@@ -62,7 +62,7 @@ public class BookingValidator {
 	 * */
 	public void validateTrainOperating(TrainSchedule trainSchedule) {
 		if (trainSchedule.getOperationStatus() == OperationStatus.CANCELLED) {
-			throw new BusinessException(TrainErrorCode.TRAIN_OPERATION_CANCELLED);
+			throw new BusinessException(TrainError.TRAIN_OPERATION_CANCELLED);
 		}
 	}
 
@@ -70,7 +70,7 @@ public class BookingValidator {
 		LocalDateTime bookingClosedAt = departureDateTime.minusMinutes(BOOKING_CLOSE_MINUTES_BEFORE_DEPARTURE);
 
 		if (!now.isBefore(bookingClosedAt)) {
-			throw new BusinessException(TrainErrorCode.DEPARTURE_TIME_PASSED);
+			throw new BusinessException(TrainError.DEPARTURE_TIME_PASSED);
 		}
 	}
 
@@ -129,7 +129,7 @@ public class BookingValidator {
 	public CarType validateSeatIdsAndGetSingleCarType(List<CarType> carTypes) {
 		if (carTypes.isEmpty()) {
 			log.warn("[좌석 조회 실패] 요청한 좌석 ID에 해당하는 좌석이 없음");
-			throw new BusinessException(TrainErrorCode.SEAT_NOT_FOUND);
+			throw new BusinessException(TrainError.SEAT_NOT_FOUND);
 		}
 
 		if (carTypes.size() != 1) {
@@ -219,7 +219,7 @@ public class BookingValidator {
 				.filter(id -> !stopMap.containsKey(id))
 				.collect(Collectors.toSet());
 			log.error("[정류장 조회 실패] scheduleStopIds={}", noExistIds);
-			throw new BusinessException(TrainErrorCode.SCHEDULE_STOP_NOT_FOUND);
+			throw new BusinessException(TrainError.SCHEDULE_STOP_NOT_FOUND);
 		}
 	}
 

--- a/src/main/java/com/sudo/raillo/booking/application/validator/BookingValidator.java
+++ b/src/main/java/com/sudo/raillo/booking/application/validator/BookingValidator.java
@@ -116,7 +116,7 @@ public class BookingValidator {
 			.toList();
 
 		if (!notFoundIds.isEmpty()) {
-			log.warn("[임시 예약 만료] pendingBookingIds={} - TTL 만료 또는 이미 사용됨", notFoundIds);
+			log.warn("[예약 만료] pendingBookingIds={} - TTL 만료 또는 이미 사용됨", notFoundIds);
 			throw new BusinessException(BookingError.PENDING_BOOKING_EXPIRED);
 		}
 	}

--- a/src/main/java/com/sudo/raillo/booking/application/validator/BookingValidator.java
+++ b/src/main/java/com/sudo/raillo/booking/application/validator/BookingValidator.java
@@ -129,7 +129,7 @@ public class BookingValidator {
 	public CarType validateSeatIdsAndGetSingleCarType(List<CarType> carTypes) {
 		if (carTypes.isEmpty()) {
 			log.warn("[좌석 조회 실패] 요청한 좌석 ID에 해당하는 좌석이 없음");
-			throw new BusinessException(BookingError.SEAT_NOT_FOUND);
+			throw new BusinessException(TrainErrorCode.SEAT_NOT_FOUND);
 		}
 
 		if (carTypes.size() != 1) {

--- a/src/main/java/com/sudo/raillo/booking/exception/BookingError.java
+++ b/src/main/java/com/sudo/raillo/booking/exception/BookingError.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum BookingError implements ErrorCode {
 
-	SEAT_NOT_FOUND("좌석을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_001"),
 	TRAIN_NOT_OPERATIONAL("운행중인 스케줄이 아닙니다.", HttpStatus.BAD_REQUEST, "B_011"),
 	BOOKING_CREATE_SEATS_INVALID("좌석 수는 총 승객 수와 같아야 합니다.", HttpStatus.BAD_REQUEST, "B_012"),
 	SEAT_BOOKING_NOT_FOUND("좌석 예약 상태를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_018"),

--- a/src/main/java/com/sudo/raillo/booking/exception/BookingError.java
+++ b/src/main/java/com/sudo/raillo/booking/exception/BookingError.java
@@ -11,38 +11,35 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum BookingError implements ErrorCode {
 
-	TRAIN_NOT_OPERATIONAL("운행중인 스케줄이 아닙니다.", HttpStatus.BAD_REQUEST, "B_011"),
-	BOOKING_CREATE_SEATS_INVALID("좌석 수는 총 승객 수와 같아야 합니다.", HttpStatus.BAD_REQUEST, "B_012"),
-	SEAT_BOOKING_NOT_FOUND("좌석 예약 상태를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_018"),
-	TICKET_NOT_FOUND("티켓을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_019"),
-	TICKET_ACCESS_DENIED("해당 티켓에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "B_022"),
-	TICKET_NOT_USABLE("사용할 수 없는 티켓입니다.", HttpStatus.BAD_REQUEST, "B_023"),
-	TICKET_NOT_CANCELLABLE("취소할 수 없는 티켓입니다.", HttpStatus.BAD_REQUEST, "B_024"),
-	BOOKING_ALREADY_CANCELLED("이미 취소된 좌석입니다", HttpStatus.BAD_REQUEST, "B_021"),
+	// 예매/좌석예약 (1xx)
+	BOOKING_NOT_FOUND("예매 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "BOOKING_101"),
+	BOOKING_ALREADY_CANCELLED("이미 취소된 좌석입니다", HttpStatus.BAD_REQUEST, "BOOKING_102"),
+	BOOKING_CREATE_SEATS_INVALID("좌석 수는 총 승객 수와 같아야 합니다.", HttpStatus.BAD_REQUEST, "BOOKING_103"),
+	INVALID_CAR_TYPE("좌석의 객차 타입은 동일해야 합니다.", HttpStatus.BAD_REQUEST, "BOOKING_104"),
+	TRAIN_NOT_OPERATIONAL("운행중인 스케줄이 아닙니다.", HttpStatus.BAD_REQUEST, "BOOKING_105"),
+	INVALID_BOOKING_TIME_FILTER("유효하지 않은 조회 필터입니다. 허용 값: upcoming, history, all", HttpStatus.BAD_REQUEST, "BOOKING_106"),
+	SEAT_BOOKING_NOT_FOUND("좌석 예매 상태를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "BOOKING_107"),
 
-	// 예약 요청 Request 관련
-	INVALID_CAR_TYPE("좌석의 객차 타입은 동일해야 합니다.", HttpStatus.BAD_REQUEST, "B_016"),
+	// 승차권 (2xx)
+	TICKET_NOT_FOUND("티켓을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "BOOKING_201"),
+	TICKET_ACCESS_DENIED("해당 티켓에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "BOOKING_202"),
+	TICKET_NOT_USABLE("사용할 수 없는 티켓입니다.", HttpStatus.BAD_REQUEST, "BOOKING_203"),
+	TICKET_NOT_CANCELLABLE("취소할 수 없는 티켓입니다.", HttpStatus.BAD_REQUEST, "BOOKING_204"),
 
-	// 예매(승차권) 조회 관련
-	BOOKING_NOT_FOUND("예매 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_101"),
-	INVALID_BOOKING_TIME_FILTER("유효하지 않은 조회 필터입니다. 허용 값: upcoming, history, all", HttpStatus.BAD_REQUEST, "B_102"),
+	// 예약(PendingBooking) (3xx)
+	PENDING_BOOKING_ACCESS_DENIED("해당 예약에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "BOOKING_301"),
+	PENDING_BOOKING_IDS_REQUIRED("조회할 예약 ID 목록이 필요합니다.", HttpStatus.BAD_REQUEST, "BOOKING_302"),
+	PENDING_BOOKING_EXPIRED("만료된 예약이 있습니다. 다시 예약해주세요.", HttpStatus.BAD_REQUEST, "BOOKING_303"),
+	INVALID_PENDING_BOOKING_TTL("예약을 처리할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "BOOKING_304"),
 
-	// PENDING_BOOKING 관련
-	PENDING_BOOKING_ACCESS_DENIED("해당 임시 예약에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "B302"),
-	PENDING_BOOKING_IDS_REQUIRED("조회할 임시 예약 ID 목록이 필요합니다.", HttpStatus.BAD_REQUEST, "B303"),
-	PENDING_BOOKING_EXPIRED("만료된 임시 예약이 있습니다. 다시 예약해주세요.", HttpStatus.BAD_REQUEST, "B304"),
-	INVALID_PENDING_BOOKING_TTL("임시 예약을 처리할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B305"),
+	// 좌석 점유·충돌 (4xx)
+	SEAT_CONFLICT_WITH_SOLD("이미 판매된 좌석이 존재하는 구간입니다.", HttpStatus.CONFLICT, "BOOKING_401"),
+	SEAT_CONFLICT_WITH_HOLD("다른 사용자가 임시 점유 중인 구간입니다.", HttpStatus.CONFLICT, "BOOKING_402"),
+	SEAT_HOLD_SCRIPT_ERROR("좌석 점유 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "BOOKING_403"),
+	SEAT_HOLD_RELEASE_FAILED("좌석 점유 해제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "BOOKING_404"),
 
-	// 좌석 충돌 관련
-	SEAT_CONFLICT_WITH_SOLD("이미 판매된 좌석이 존재하는 구간입니다.", HttpStatus.CONFLICT, "B_304"),
-	SEAT_CONFLICT_WITH_HOLD("다른 사용자가 임시 점유 중인 구간입니다.", HttpStatus.CONFLICT, "B_305"),
-
-	// Seat Hold 관련
-	SEAT_HOLD_SCRIPT_ERROR("좌석 점유 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_306"),
-	SEAT_HOLD_RELEASE_FAILED("좌석 점유 해제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_309"),
-
-	// 영수증 관련
-	RECEIPT_NOT_FOUND("영수증 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B401");
+	// 영수증 (5xx)
+	RECEIPT_NOT_FOUND("영수증 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "BOOKING_501");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/booking/exception/BookingError.java
+++ b/src/main/java/com/sudo/raillo/booking/exception/BookingError.java
@@ -12,26 +12,13 @@ import lombok.RequiredArgsConstructor;
 public enum BookingError implements ErrorCode {
 
 	SEAT_NOT_FOUND("좌석을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_001"),
-	SEAT_ALREADY_BOOKED("이미 예약된 좌석입니다.", HttpStatus.CONFLICT, "B_002"),
-	SEAT_BOOKING_FAILED("좌석 예약에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_003"),
-	SEAT_CANCELLATION_FAILED("좌석 취소에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_004"),
-	SEAT_ALREADY_CANCELLED("이미 취소된 좌석입니다.", HttpStatus.CONFLICT, "B_005"),
-	SEAT_NOT_AVAILABLE("사용가능한 좌석이 아닙니다.", HttpStatus.BAD_REQUEST, "B_006"),
-	SEAT_NOT_BOOKED("예약된 좌석이 아닙니다.", HttpStatus.BAD_REQUEST, "B_007"),
-	EXPIRED_SEAT_CANCELLATION_FAILED("만료된 좌석 취소에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_008"),
-	BOOKING_CREATE_FAILED("예약에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_009"),
-	BOOKING_DELETE_FAILED("예약 취소에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_010"),
 	TRAIN_NOT_OPERATIONAL("운행중인 스케줄이 아닙니다.", HttpStatus.BAD_REQUEST, "B_011"),
 	BOOKING_CREATE_SEATS_INVALID("좌석 수는 총 승객 수와 같아야 합니다.", HttpStatus.BAD_REQUEST, "B_012"),
-	TICKET_CREATE_FAILED("티켓 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_014"),
-	TICKET_LIST_GET_FAILED("티켓을 가져올 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_015"),
-	BOOKING_EXPIRED("예약이 만료되었습니다.", HttpStatus.GONE, "B_017"),
 	SEAT_BOOKING_NOT_FOUND("좌석 예약 상태를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_018"),
 	TICKET_NOT_FOUND("티켓을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_019"),
 	TICKET_ACCESS_DENIED("해당 티켓에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "B_022"),
 	TICKET_NOT_USABLE("사용할 수 없는 티켓입니다.", HttpStatus.BAD_REQUEST, "B_023"),
 	TICKET_NOT_CANCELLABLE("취소할 수 없는 티켓입니다.", HttpStatus.BAD_REQUEST, "B_024"),
-	INVALID_TOTAL_FAIR("예약 총 금액은 0보다 크거나 같아야 합니다", HttpStatus.BAD_REQUEST, "B_020"),
 	BOOKING_ALREADY_CANCELLED("이미 취소된 좌석입니다", HttpStatus.BAD_REQUEST, "B_021"),
 
 	// 예약 요청 Request 관련
@@ -41,26 +28,19 @@ public enum BookingError implements ErrorCode {
 	BOOKING_NOT_FOUND("예매 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_101"),
 	INVALID_BOOKING_TIME_FILTER("유효하지 않은 조회 필터입니다. 허용 값: upcoming, history, all", HttpStatus.BAD_REQUEST, "B_102"),
 
-
 	// PENDING_BOOKING 관련
-	PENDING_BOOKING_NOT_FOUND("임시 예약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B301"),
 	PENDING_BOOKING_ACCESS_DENIED("해당 임시 예약에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "B302"),
 	PENDING_BOOKING_IDS_REQUIRED("조회할 임시 예약 ID 목록이 필요합니다.", HttpStatus.BAD_REQUEST, "B303"),
 	PENDING_BOOKING_EXPIRED("만료된 임시 예약이 있습니다. 다시 예약해주세요.", HttpStatus.BAD_REQUEST, "B304"),
 	INVALID_PENDING_BOOKING_TTL("임시 예약을 처리할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B305"),
 
-	// BookingError.java에 추가할 부분
-
-	// 좌석 충돌 관련 (기존 SEAT 관련 에러 아래에 추가)
+	// 좌석 충돌 관련
 	SEAT_CONFLICT_WITH_SOLD("이미 판매된 좌석이 존재하는 구간입니다.", HttpStatus.CONFLICT, "B_304"),
 	SEAT_CONFLICT_WITH_HOLD("다른 사용자가 임시 점유 중인 구간입니다.", HttpStatus.CONFLICT, "B_305"),
 
 	// Seat Hold 관련
 	SEAT_HOLD_SCRIPT_ERROR("좌석 점유 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_306"),
-	SEAT_HOLD_NOT_FOUND("임시 점유 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_307"),
-	SEAT_HOLD_CONFIRM_FAILED("좌석 확정 처리에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_308"),
 	SEAT_HOLD_RELEASE_FAILED("좌석 점유 해제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "B_309"),
-	SEAT_HOLD_SECTION_NOT_FOUND("좌석 점유 구간을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B_310"),
 
 	// 영수증 관련
 	RECEIPT_NOT_FOUND("영수증 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "B401");

--- a/src/main/java/com/sudo/raillo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sudo/raillo/global/exception/GlobalExceptionHandler.java
@@ -58,8 +58,7 @@ public class GlobalExceptionHandler {
 
 		return ResponseEntity.badRequest().body(
 			ErrorResponse.of(
-				"G_400",
-				"요청 본문이 필요합니다. JSON 형식의 데이터를 포함해주세요.",
+				GlobalError.REQUEST_BODY_MISSING,
 				Map.of(
 					"path", "uri=" + request.getRequestURI(),
 					"method", request.getMethod()

--- a/src/main/java/com/sudo/raillo/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/sudo/raillo/global/exception/error/ErrorCode.java
@@ -2,6 +2,11 @@ package com.sudo.raillo.global.exception.error;
 
 import org.springframework.http.HttpStatus;
 
+/**
+ * 도메인별 에러 코드 enum이 구현하는 인터페이스.
+ *
+ * <p>코드 형식({@code {DOMAIN}_{NNN}})·접두사·카테고리 밴드 컨벤션 → docs/error-code-convention.md
+ */
 public interface ErrorCode {
 
 	String getMessage();

--- a/src/main/java/com/sudo/raillo/global/exception/error/GlobalError.java
+++ b/src/main/java/com/sudo/raillo/global/exception/error/GlobalError.java
@@ -10,18 +10,18 @@ import lombok.RequiredArgsConstructor;
 public enum GlobalError implements ErrorCode {
 
 	// 4xx 클라이언트 에러
-	INVALID_REQUEST_PARAM("요청 파라미터가 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "G_001"),
-	MISSING_REQUEST_PARAM("필수 요청 파라미터가 누락되었습니다.", HttpStatus.BAD_REQUEST, "G_002"),
-	INVALID_REQUEST_BODY("요청 본문이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "G_003"),
-	RESOURCE_NOT_FOUND("요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "G_004"),
-	RESOURCE_ALREADY_EXISTS("이미 존재하는 리소스입니다.", HttpStatus.CONFLICT, "G_005"),
-	UNAUTHORIZED_ACCESS("인증이 필요합니다.", HttpStatus.UNAUTHORIZED, "G_006"),
-	FORBIDDEN_ACCESS("접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "G_007"),
-	INVALID_YN_VALUE("Y 또는 N 값만 허용됩니다.", HttpStatus.BAD_REQUEST, "G_009"),
+	INVALID_REQUEST_PARAM("요청 파라미터가 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "GLOBAL_001"),
+	MISSING_REQUEST_PARAM("필수 요청 파라미터가 누락되었습니다.", HttpStatus.BAD_REQUEST, "GLOBAL_002"),
+	INVALID_REQUEST_BODY("요청 본문이 유효하지 않습니다.", HttpStatus.BAD_REQUEST, "GLOBAL_003"),
+	RESOURCE_NOT_FOUND("요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "GLOBAL_004"),
+	RESOURCE_ALREADY_EXISTS("이미 존재하는 리소스입니다.", HttpStatus.CONFLICT, "GLOBAL_005"),
+	UNAUTHORIZED_ACCESS("인증이 필요합니다.", HttpStatus.UNAUTHORIZED, "GLOBAL_006"),
+	FORBIDDEN_ACCESS("접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "GLOBAL_007"),
+	INVALID_YN_VALUE("Y 또는 N 값만 허용됩니다.", HttpStatus.BAD_REQUEST, "GLOBAL_008"),
 
 	// 5xx 서버 에러
-	INTERNAL_SERVER_ERROR("내부 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "G_500"),
-	DATABASE_ERROR("데이터베이스 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "G_501");
+	INTERNAL_SERVER_ERROR("내부 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_501"),
+	DATABASE_ERROR("데이터베이스 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_502");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/global/exception/error/GlobalError.java
+++ b/src/main/java/com/sudo/raillo/global/exception/error/GlobalError.java
@@ -18,6 +18,7 @@ public enum GlobalError implements ErrorCode {
 	UNAUTHORIZED_ACCESS("인증이 필요합니다.", HttpStatus.UNAUTHORIZED, "GLOBAL_006"),
 	FORBIDDEN_ACCESS("접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "GLOBAL_007"),
 	INVALID_YN_VALUE("Y 또는 N 값만 허용됩니다.", HttpStatus.BAD_REQUEST, "GLOBAL_008"),
+	REQUEST_BODY_MISSING("요청 본문이 필요합니다. JSON 형식의 데이터를 포함해주세요.", HttpStatus.BAD_REQUEST, "GLOBAL_009"),
 
 	// 5xx 서버 에러
 	INTERNAL_SERVER_ERROR("내부 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_501"),

--- a/src/main/java/com/sudo/raillo/global/exception/error/GlobalError.java
+++ b/src/main/java/com/sudo/raillo/global/exception/error/GlobalError.java
@@ -17,13 +17,11 @@ public enum GlobalError implements ErrorCode {
 	RESOURCE_ALREADY_EXISTS("이미 존재하는 리소스입니다.", HttpStatus.CONFLICT, "G_005"),
 	UNAUTHORIZED_ACCESS("인증이 필요합니다.", HttpStatus.UNAUTHORIZED, "G_006"),
 	FORBIDDEN_ACCESS("접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "G_007"),
-	METHOD_NOT_ALLOWED("허용되지 않은 HTTP 메소드입니다.", HttpStatus.METHOD_NOT_ALLOWED, "G_008"),
 	INVALID_YN_VALUE("Y 또는 N 값만 허용됩니다.", HttpStatus.BAD_REQUEST, "G_009"),
 
 	// 5xx 서버 에러
 	INTERNAL_SERVER_ERROR("내부 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "G_500"),
-	DATABASE_ERROR("데이터베이스 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "G_501"),
-	EXTERNAL_API_ERROR("외부 API 호출 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "G_502");
+	DATABASE_ERROR("데이터베이스 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "G_501");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/global/redis/exception/RedisError.java
+++ b/src/main/java/com/sudo/raillo/global/redis/exception/RedisError.java
@@ -11,11 +11,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RedisError implements ErrorCode {
 
-	REDIS_CONNECT_FAIL("Redis 서버 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "R_001"),
-	SERIALIZATION_FAIL("Json data 직렬화/역직렬화에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "R_002"),
-	INVALID_DATA_ACCESS("잘못된 Redis API 사용입니다.", HttpStatus.BAD_REQUEST, "R_003"),
-	SCAN_OPERATION_FAIL("키 스캔중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "R_004"),
-	MGET_OPERATION_FAIL("여러 키 조회중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "R_005");
+	REDIS_CONNECT_FAIL("Redis 서버 연결에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_001"),
+	SERIALIZATION_FAIL("Json data 직렬화/역직렬화에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_002"),
+	INVALID_DATA_ACCESS("잘못된 Redis API 사용입니다.", HttpStatus.BAD_REQUEST, "REDIS_003"),
+	SCAN_OPERATION_FAIL("키 스캔중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_004"),
+	MGET_OPERATION_FAIL("여러 키 조회중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_005");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/member/exception/MemberError.java
+++ b/src/main/java/com/sudo/raillo/member/exception/MemberError.java
@@ -11,16 +11,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberError implements ErrorCode {
 
-	USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "M_001"),
-	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT, "M_002"),
-	INVALID_PASSWORD("비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED, "M_003"),
-	MEMBER_DELETE_FAIL("회원 삭제에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "M_005"),
-	SAME_PHONE_NUMBER("현재 사용하는 휴대폰 번호와 동일합니다.", HttpStatus.CONFLICT, "M_006"),
-	DUPLICATE_PHONE_NUMBER("이미 사용 중인 휴대폰 번호입니다.", HttpStatus.CONFLICT, "M_007"),
-	SAME_EMAIL("현재 사용중인 이메일과 동일합니다.", HttpStatus.CONFLICT, "M_008"),
-	SAME_PASSWORD("현재 사용중인 비밀번호와 동일합니다.", HttpStatus.CONFLICT, "M_009"),
-	NAME_MISMATCH("이름이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "M_010"),
-	EMAIL_UPDATE_ALREADY_REQUESTED("해당 이메일에 대한 변경 요청이 이미 처리중입니다.", HttpStatus.CONFLICT, "M_011");
+	USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "MEMBER_001"),
+	DUPLICATE_EMAIL("이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT, "MEMBER_002"),
+	INVALID_PASSWORD("비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED, "MEMBER_003"),
+	MEMBER_DELETE_FAIL("회원 삭제에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_004"),
+	SAME_PHONE_NUMBER("현재 사용하는 휴대폰 번호와 동일합니다.", HttpStatus.CONFLICT, "MEMBER_005"),
+	DUPLICATE_PHONE_NUMBER("이미 사용 중인 휴대폰 번호입니다.", HttpStatus.CONFLICT, "MEMBER_006"),
+	SAME_EMAIL("현재 사용중인 이메일과 동일합니다.", HttpStatus.CONFLICT, "MEMBER_007"),
+	SAME_PASSWORD("현재 사용중인 비밀번호와 동일합니다.", HttpStatus.CONFLICT, "MEMBER_008"),
+	NAME_MISMATCH("이름이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "MEMBER_009"),
+	EMAIL_UPDATE_ALREADY_REQUESTED("해당 이메일에 대한 변경 요청이 이미 처리중입니다.", HttpStatus.CONFLICT, "MEMBER_010");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/order/application/OrderService.java
+++ b/src/main/java/com/sudo/raillo/order/application/OrderService.java
@@ -20,7 +20,7 @@ import com.sudo.raillo.order.infrastructure.OrderSeatBookingRepository;
 import com.sudo.raillo.train.domain.ScheduleStop;
 import com.sudo.raillo.train.domain.Seat;
 import com.sudo.raillo.train.domain.TrainSchedule;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.ScheduleStopRepository;
 import com.sudo.raillo.train.infrastructure.SeatRepository;
 import com.sudo.raillo.train.infrastructure.TrainScheduleRepository;
@@ -152,7 +152,7 @@ public class OrderService {
 		List<Seat> seats = seatRepository.findAllByIdWithTrainCar(seatIds);
 
 		if (seats.size() != seatIds.size()) {
-			throw new BusinessException(TrainErrorCode.SEAT_NOT_FOUND);
+			throw new BusinessException(TrainError.SEAT_NOT_FOUND);
 		}
 
 		return seats.stream().collect(Collectors.toMap(Seat::getId, seat -> seat));
@@ -166,7 +166,7 @@ public class OrderService {
 		List<TrainSchedule> schedules = trainScheduleRepository.findAllByIdWithTrain(scheduleIds);
 
 		if (schedules.size() != scheduleIds.size()) {
-			throw new BusinessException(TrainErrorCode.TRAIN_SCHEDULE_DETAIL_NOT_FOUND);
+			throw new BusinessException(TrainError.TRAIN_SCHEDULE_DETAIL_NOT_FOUND);
 		}
 
 		return schedules.stream().collect(Collectors.toMap(TrainSchedule::getId, schedule -> schedule));
@@ -180,7 +180,7 @@ public class OrderService {
 		List<ScheduleStop> stops = scheduleStopRepository.findAllByIdWithStation(stopIds);
 
 		if (stops.size() != stopIds.size()) {
-			throw new BusinessException(TrainErrorCode.STATION_NOT_FOUND);
+			throw new BusinessException(TrainError.STATION_NOT_FOUND);
 		}
 
 		return stops.stream().collect(Collectors.toMap(ScheduleStop::getId, scheduleStop -> scheduleStop));

--- a/src/main/java/com/sudo/raillo/order/exception/OrderError.java
+++ b/src/main/java/com/sudo/raillo/order/exception/OrderError.java
@@ -8,15 +8,15 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum OrderError implements ErrorCode {
-	NOT_PENDING("주문 대기 상태가 아닙니다", HttpStatus.BAD_REQUEST, "O_001"),
-	NOT_ORDERED("결제 완료된 주문 상태가 아닙니다", HttpStatus.BAD_REQUEST, "O_002"),
-	INVALID_TOTAL_AMOUNT("주문 총 금액은 0보다 크거나 같아야 합니다", HttpStatus.BAD_REQUEST, "O_003"),
-	ORDER_NOT_FOUND("주문 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST, "O_004"),
-	ORDER_ACCESS_DENIED("주문에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "O_005"),
-	EMPTY_PENDING_BOOKINGS("주문할 예약 정보가 없습니다.", HttpStatus.BAD_REQUEST, "O_006"),
-	ORDER_BOOKING_NOT_FOUND("주문 예약 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST, "O_007"),
-	ORDER_SEAT_BOOKING_NOT_FOUND("주문 좌석 예약 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST, "O_008"),
-	ORDER_IS_EXPIRED("만료된 주문입니다.", HttpStatus.GONE, "O_009");
+	NOT_PENDING("주문 대기 상태가 아닙니다", HttpStatus.BAD_REQUEST, "ORDER_001"),
+	NOT_ORDERED("결제 완료된 주문 상태가 아닙니다", HttpStatus.BAD_REQUEST, "ORDER_002"),
+	INVALID_TOTAL_AMOUNT("주문 총 금액은 0보다 크거나 같아야 합니다", HttpStatus.BAD_REQUEST, "ORDER_003"),
+	ORDER_NOT_FOUND("주문 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST, "ORDER_004"),
+	ORDER_ACCESS_DENIED("주문에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "ORDER_005"),
+	EMPTY_PENDING_BOOKINGS("주문할 예약 정보가 없습니다.", HttpStatus.BAD_REQUEST, "ORDER_006"),
+	ORDER_BOOKING_NOT_FOUND("주문 예약 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST, "ORDER_007"),
+	ORDER_SEAT_BOOKING_NOT_FOUND("주문 좌석 예약 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST, "ORDER_008"),
+	ORDER_IS_EXPIRED("만료된 주문입니다.", HttpStatus.GONE, "ORDER_009");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/payment/exception/PaymentError.java
+++ b/src/main/java/com/sudo/raillo/payment/exception/PaymentError.java
@@ -11,11 +11,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum PaymentError implements ErrorCode {
 
-	// 예약 관련 에러
-	BOOKING_NOT_FOUND("예약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "P_001"),
-	BOOKING_ACCESS_DENIED("예약에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "P_002"),
-	BOOKING_NOT_PAYABLE("결제할 수 없는 예약 상태입니다.", HttpStatus.BAD_REQUEST, "P_003"),
-
 	// 결제 관련 에러
 	PAYMENT_NOT_FOUND("결제 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "P_004"),
 	PAYMENT_ACCESS_DENIED("결제에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "P_005"),
@@ -24,18 +19,14 @@ public enum PaymentError implements ErrorCode {
 	PAYMENT_NOT_APPROVABLE("승인할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "P_008"),
 	PAYMENT_NOT_REFUNDABLE("환불할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "P_013"),
 	PAYMENT_CANNOT_FAIL("실패 처리할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "P_014"),
-	PAYMENT_PROCESS_FAILED("결제 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "P_009"),
 
 	// 금액 관련 에러
-	INVALID_PAYMENT_AMOUNT("유효하지 않은 결제 금액입니다.", HttpStatus.BAD_REQUEST, "P_010"),
 	PAYMENT_AMOUNT_MISMATCH("결제 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "P_011"),
 
 	// 결제 수단 관련 에러
 	INVALID_PAYMENT_METHOD("지원하지 않는 결제 수단입니다.", HttpStatus.BAD_REQUEST, "P_012"),
 
-	// TOSS 에러
-	TOSS_PAYMENT_FAILED("토스 결제중 오류가 발생했습니다.", HttpStatus.BAD_REQUEST, "P_201"),
-	TOSS_SERVER_ERROR("토스 결제 서버에 일시적인 문제가 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.BAD_GATEWAY, "P_202"),
+	// 결제 키 관련 에러
 	PAYMENT_KEY_MISMATCH("결제 키가 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "P_0203"),
 
 	// 시스템 에러

--- a/src/main/java/com/sudo/raillo/payment/exception/PaymentError.java
+++ b/src/main/java/com/sudo/raillo/payment/exception/PaymentError.java
@@ -11,26 +11,22 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum PaymentError implements ErrorCode {
 
-	// 결제 관련 에러
-	PAYMENT_NOT_FOUND("결제 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "P_004"),
-	PAYMENT_ACCESS_DENIED("결제에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "P_005"),
-	PAYMENT_ALREADY_COMPLETED("이미 결제가 완료된 주문입니다.", HttpStatus.BAD_REQUEST, "P_006"),
-	PAYMENT_NOT_CANCELLABLE("취소할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "P_007"),
-	PAYMENT_NOT_APPROVABLE("승인할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "P_008"),
-	PAYMENT_NOT_REFUNDABLE("환불할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "P_013"),
-	PAYMENT_CANNOT_FAIL("실패 처리할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "P_014"),
+	// 결제 상태 (1xx)
+	PAYMENT_NOT_FOUND("결제 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "PAYMENT_101"),
+	PAYMENT_ACCESS_DENIED("결제에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN, "PAYMENT_102"),
+	PAYMENT_ALREADY_COMPLETED("이미 결제가 완료된 주문입니다.", HttpStatus.BAD_REQUEST, "PAYMENT_103"),
+	PAYMENT_NOT_CANCELLABLE("취소할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "PAYMENT_104"),
+	PAYMENT_NOT_APPROVABLE("승인할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "PAYMENT_105"),
+	PAYMENT_NOT_REFUNDABLE("환불할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "PAYMENT_106"),
+	PAYMENT_CANNOT_FAIL("실패 처리할 수 없는 결제 상태입니다.", HttpStatus.BAD_REQUEST, "PAYMENT_107"),
 
-	// 금액 관련 에러
-	PAYMENT_AMOUNT_MISMATCH("결제 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "P_011"),
+	// 금액/수단/키 (2xx)
+	PAYMENT_AMOUNT_MISMATCH("결제 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "PAYMENT_201"),
+	INVALID_PAYMENT_METHOD("지원하지 않는 결제 수단입니다.", HttpStatus.BAD_REQUEST, "PAYMENT_202"),
+	PAYMENT_KEY_MISMATCH("결제 키가 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "PAYMENT_203"),
 
-	// 결제 수단 관련 에러
-	INVALID_PAYMENT_METHOD("지원하지 않는 결제 수단입니다.", HttpStatus.BAD_REQUEST, "P_012"),
-
-	// 결제 키 관련 에러
-	PAYMENT_KEY_MISMATCH("결제 키가 일치하지 않습니다.", HttpStatus.BAD_REQUEST, "P_0203"),
-
-	// 시스템 에러
-	PAYMENT_SYSTEM_ERROR("결제 시스템 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "P_999");
+	// 시스템 (9xx)
+	PAYMENT_SYSTEM_ERROR("결제 시스템 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT_901");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/train/application/calculator/FareCalculator.java
+++ b/src/main/java/com/sudo/raillo/train/application/calculator/FareCalculator.java
@@ -4,7 +4,7 @@ import com.sudo.raillo.booking.domain.type.PassengerType;
 import com.sudo.raillo.global.exception.error.BusinessException;
 import com.sudo.raillo.train.domain.StationFare;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.StationFareRepository;
 import java.math.BigDecimal;
 import java.util.List;
@@ -76,7 +76,7 @@ public class FareCalculator {
 	private StationFare findStationFare(Long departureStationId, Long arrivalStationId) {
 		return stationFareRepository
 			.findByDepartureStationIdAndArrivalStationId(departureStationId, arrivalStationId)
-			.orElseThrow(() -> new BusinessException(TrainErrorCode.STATION_FARE_NOT_FOUND));
+			.orElseThrow(() -> new BusinessException(TrainError.STATION_FARE_NOT_FOUND));
 	}
 
 	/**

--- a/src/main/java/com/sudo/raillo/train/application/facade/TrainSearchFacade.java
+++ b/src/main/java/com/sudo/raillo/train/application/facade/TrainSearchFacade.java
@@ -31,7 +31,7 @@ import com.sudo.raillo.train.domain.ScheduleStop;
 import com.sudo.raillo.train.domain.StationFare;
 import com.sudo.raillo.train.domain.TrainSchedule;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -216,7 +216,7 @@ public class TrainSearchFacade {
 
 		if (results.isEmpty()) {
 			log.warn("처리 가능한 열차 없음");
-			throw new BusinessException(TrainErrorCode.NO_SEARCH_RESULTS);
+			throw new BusinessException(TrainError.NO_SEARCH_RESULTS);
 		}
 
 		log.info("배치 처리 완료: 전체 {}건 중 {}건 성공", trainInfoSlice.size(), results.size());
@@ -294,7 +294,7 @@ public class TrainSearchFacade {
 			.toList();
 
 		if (adjustedCars.isEmpty()) {
-			throw new BusinessException(TrainErrorCode.NO_AVAILABLE_CARS);
+			throw new BusinessException(TrainError.NO_AVAILABLE_CARS);
 		}
 
 		return adjustedCars;

--- a/src/main/java/com/sudo/raillo/train/application/service/CarRecommendationService.java
+++ b/src/main/java/com/sudo/raillo/train/application/service/CarRecommendationService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.sudo.raillo.global.exception.error.BusinessException;
 import com.sudo.raillo.train.application.dto.response.TrainCarInfo;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 
 @Service
 public class CarRecommendationService {
@@ -21,7 +21,7 @@ public class CarRecommendationService {
 	 */
 	public String selectRecommendedCar(List<TrainCarInfo> availableCars, int passengerCount) {
 		if (availableCars.isEmpty()) {
-			throw new BusinessException(TrainErrorCode.NO_AVAILABLE_CARS);
+			throw new BusinessException(TrainError.NO_AVAILABLE_CARS);
 		}
 
 		List<TrainCarInfo> suitableCars = findSuitableCars(availableCars, passengerCount);

--- a/src/main/java/com/sudo/raillo/train/application/service/TrainScheduleService.java
+++ b/src/main/java/com/sudo/raillo/train/application/service/TrainScheduleService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import com.sudo.raillo.global.exception.error.BusinessException;
 import com.sudo.raillo.train.domain.ScheduleStop;
 import com.sudo.raillo.train.domain.TrainSchedule;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.ScheduleStopRepository;
 import com.sudo.raillo.train.infrastructure.TrainScheduleRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,12 +25,12 @@ public class TrainScheduleService {
 
 	public TrainSchedule getTrainSchedule(Long trainScheduleId) {
 		return trainScheduleRepository.findById(trainScheduleId)
-			.orElseThrow(() -> new BusinessException(TrainErrorCode.TRAIN_SCHEDULE_NOT_FOUND));
+			.orElseThrow(() -> new BusinessException(TrainError.TRAIN_SCHEDULE_NOT_FOUND));
 	}
 
 	public ScheduleStop getStopStation(TrainSchedule trainSchedule, Long stationId) {
 		return scheduleStopRepository.findByTrainScheduleIdAndStationId(trainSchedule.getId(), stationId)
-			.orElseThrow(() -> new BusinessException(TrainErrorCode.STATION_NOT_FOUND));
+			.orElseThrow(() -> new BusinessException(TrainError.STATION_NOT_FOUND));
 	}
 
 	public List<ScheduleStop> getScheduleStops(List<Long> stopIds) {

--- a/src/main/java/com/sudo/raillo/train/application/service/TrainSearchService.java
+++ b/src/main/java/com/sudo/raillo/train/application/service/TrainSearchService.java
@@ -18,7 +18,7 @@ import com.sudo.raillo.train.application.dto.projection.TrainSeatInfoBatch;
 import com.sudo.raillo.train.application.dto.request.TrainSearchRequest;
 import com.sudo.raillo.train.domain.StationFare;
 import com.sudo.raillo.train.domain.TrainSchedule;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.SeatBookingQueryRepository;
 import com.sudo.raillo.train.infrastructure.StationFareRepository;
 import com.sudo.raillo.train.infrastructure.TrainScheduleQueryRepository;
@@ -64,7 +64,7 @@ public class TrainSearchService {
 		return stationFareRepository.findByDepartureStationIdAndArrivalStationId(departureStationId, arrivalStationId)
 			.orElseThrow(() -> {
 				log.error("요금 정보 없음: {} -> {}", departureStationId, arrivalStationId);
-				return new BusinessException(TrainErrorCode.STATION_FARE_NOT_FOUND);
+				return new BusinessException(TrainError.STATION_FARE_NOT_FOUND);
 			});
 	}
 
@@ -73,7 +73,7 @@ public class TrainSearchService {
 	 */
 	public TrainScheduleBasicInfo getTrainScheduleBasicInfo(Long trainScheduleId) {
 		TrainSchedule trainSchedule = trainScheduleRepository.findById(trainScheduleId)
-			.orElseThrow(() -> new BusinessException(TrainErrorCode.TRAIN_SCHEDULE_DETAIL_NOT_FOUND));
+			.orElseThrow(() -> new BusinessException(TrainError.TRAIN_SCHEDULE_DETAIL_NOT_FOUND));
 
 		return new TrainScheduleBasicInfo(
 			trainSchedule.getId(),

--- a/src/main/java/com/sudo/raillo/train/application/service/TrainSeatQueryService.java
+++ b/src/main/java/com/sudo/raillo/train/application/service/TrainSeatQueryService.java
@@ -5,7 +5,7 @@ import com.sudo.raillo.train.application.dto.TrainCarSeatInfo;
 import com.sudo.raillo.train.application.dto.request.TrainCarSeatDetailRequest;
 import com.sudo.raillo.train.application.dto.response.TrainCarInfo;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.SeatQueryRepository;
 import com.sudo.raillo.train.infrastructure.SeatRepository;
 import com.sudo.raillo.train.infrastructure.TrainCarQueryRepository;
@@ -36,7 +36,7 @@ public class TrainSeatQueryService {
 
 		if (availableCars.isEmpty()) {
 			log.warn("잔여 좌석이 있는 객차가 없음: trainScheduleId={}", trainScheduleId);
-			throw new BusinessException(TrainErrorCode.NO_AVAILABLE_CARS);
+			throw new BusinessException(TrainError.NO_AVAILABLE_CARS);
 		}
 
 		return availableCars;
@@ -53,10 +53,10 @@ public class TrainSeatQueryService {
 			request.arrivalStationId()
 		);
 		if (carSeatInfo.departureStopOrder() == null || carSeatInfo.arrivalStopOrder() == null) {
-			throw new BusinessException(TrainErrorCode.SCHEDULE_STOP_NOT_FOUND);
+			throw new BusinessException(TrainError.SCHEDULE_STOP_NOT_FOUND);
 		}
 		if (carSeatInfo.departureStopOrder() >= carSeatInfo.arrivalStopOrder()) {
-			throw new BusinessException(TrainErrorCode.INVALID_ROUTE);
+			throw new BusinessException(TrainError.INVALID_ROUTE);
 		}
 
 		log.info("열차 객차 좌석 상세 조회 완료: 객차={}, 전체좌석={}, 잔여좌석={}",

--- a/src/main/java/com/sudo/raillo/train/application/validator/TrainSearchValidator.java
+++ b/src/main/java/com/sudo/raillo/train/application/validator/TrainSearchValidator.java
@@ -9,7 +9,7 @@ import com.sudo.raillo.global.exception.error.BusinessException;
 import com.sudo.raillo.train.application.dto.request.TrainCarListRequest;
 import com.sudo.raillo.train.application.dto.request.TrainCarSeatDetailRequest;
 import com.sudo.raillo.train.application.dto.request.TrainSearchRequest;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.StationRepository;
 import com.sudo.raillo.train.infrastructure.TrainCarRepository;
 import com.sudo.raillo.train.infrastructure.TrainScheduleRepository;
@@ -67,7 +67,7 @@ public class TrainSearchValidator {
 	private void validateDepartureAndArrivalStationNotSame(Long departureStationId, Long arrivalStationId) {
 		if (departureStationId.equals(arrivalStationId)) {
 			log.warn("출발역과 도착역이 동일함: stationId={}", departureStationId);
-			throw new BusinessException(TrainErrorCode.INVALID_ROUTE);
+			throw new BusinessException(TrainError.INVALID_ROUTE);
 		}
 	}
 
@@ -76,7 +76,7 @@ public class TrainSearchValidator {
 	 */
 	private void validateOperationDateRange(TrainSearchRequest request) {
 		if (request.operationDate().isAfter(LocalDate.now().plusMonths(1))) {
-			throw new BusinessException(TrainErrorCode.OPERATION_DATE_TOO_FAR);
+			throw new BusinessException(TrainError.OPERATION_DATE_TOO_FAR);
 		}
 	}
 
@@ -90,7 +90,7 @@ public class TrainSearchValidator {
 			int currentHour = LocalTime.now().getHour();
 
 			if (requestHour < currentHour) {
-				throw new BusinessException(TrainErrorCode.DEPARTURE_TIME_PASSED);
+				throw new BusinessException(TrainError.DEPARTURE_TIME_PASSED);
 			}
 		}
 	}
@@ -103,7 +103,7 @@ public class TrainSearchValidator {
 	private void validateTrainScheduleExists(Long trainScheduleId) {
 		if (!trainScheduleRepository.existsById(trainScheduleId)) {
 			log.warn("존재하지 않는 열차 스케줄: trainScheduleId={}", trainScheduleId);
-			throw new BusinessException(TrainErrorCode.TRAIN_SCHEDULE_NOT_FOUND);
+			throw new BusinessException(TrainError.TRAIN_SCHEDULE_NOT_FOUND);
 		}
 	}
 
@@ -113,7 +113,7 @@ public class TrainSearchValidator {
 	private void validateTrainCarExists(Long trainCarId) {
 		if (!trainCarRepository.existsById(trainCarId)) {
 			log.warn("존재하지 않는 객차: trainCarId={}", trainCarId);
-			throw new BusinessException(TrainErrorCode.TRAIN_CAR_NOT_FOUND);
+			throw new BusinessException(TrainError.TRAIN_CAR_NOT_FOUND);
 		}
 	}
 
@@ -123,7 +123,7 @@ public class TrainSearchValidator {
 	private void validateStationExists(Long stationId, String stationType) {
 		if (!stationRepository.existsById(stationId)) {
 			log.warn("존재하지 않는 {}: stationId={}", stationType, stationId);
-			throw new BusinessException(TrainErrorCode.STATION_NOT_FOUND);
+			throw new BusinessException(TrainError.STATION_NOT_FOUND);
 		}
 	}
 

--- a/src/main/java/com/sudo/raillo/train/exception/TrainError.java
+++ b/src/main/java/com/sudo/raillo/train/exception/TrainError.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum TrainErrorCode implements ErrorCode {
+public enum TrainError implements ErrorCode {
 
 	// 열차 조회 관련
 	TRAIN_SCHEDULE_NOT_FOUND("해당 날짜에 운행하는 열차가 없습니다.", HttpStatus.NOT_FOUND, "T4001"),

--- a/src/main/java/com/sudo/raillo/train/exception/TrainError.java
+++ b/src/main/java/com/sudo/raillo/train/exception/TrainError.java
@@ -11,28 +11,26 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TrainError implements ErrorCode {
 
-	// 열차 조회 관련
-	TRAIN_SCHEDULE_NOT_FOUND("해당 날짜에 운행하는 열차가 없습니다.", HttpStatus.NOT_FOUND, "T4001"),
-	TRAIN_OPERATION_CANCELLED("해당 열차는 운행이 취소되었습니다.", HttpStatus.BAD_REQUEST, "T4002"),
-	TRAIN_SCHEDULE_DETAIL_NOT_FOUND("해당 열차 스케줄을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T4004"),
-	NO_AVAILABLE_CARS("잔여 좌석이 있는 객차가 없습니다.", HttpStatus.NOT_FOUND, "T_4005"),
-	TRAIN_CAR_NOT_FOUND("해당 객차를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T_4006"),
+	// 열차/스케줄 (1xx)
+	TRAIN_SCHEDULE_NOT_FOUND("해당 날짜에 운행하는 열차가 없습니다.", HttpStatus.NOT_FOUND, "TRAIN_101"),
+	TRAIN_SCHEDULE_DETAIL_NOT_FOUND("해당 열차 스케줄을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "TRAIN_102"),
+	TRAIN_OPERATION_CANCELLED("해당 열차는 운행이 취소되었습니다.", HttpStatus.BAD_REQUEST, "TRAIN_103"),
 
-	// 좌석 예약 관련
-	SEAT_NOT_FOUND("좌석을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T4106"),
+	// 객차/좌석 (2xx)
+	NO_AVAILABLE_CARS("잔여 좌석이 있는 객차가 없습니다.", HttpStatus.NOT_FOUND, "TRAIN_201"),
+	TRAIN_CAR_NOT_FOUND("해당 객차를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "TRAIN_202"),
+	SEAT_NOT_FOUND("좌석을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "TRAIN_203"),
 
-	// 역 및 구간 관련
-	STATION_NOT_FOUND("존재하지 않는 역입니다.", HttpStatus.NOT_FOUND, "T4201"),
-	STATION_FARE_NOT_FOUND("해당 구간의 요금 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T4202"),
-	INVALID_ROUTE("출발역과 도착역이 동일하거나 유효하지 않은 경로입니다.", HttpStatus.BAD_REQUEST, "T4203"),
-	SCHEDULE_STOP_NOT_FOUND("정류장 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T4204"),
+	// 역/구간/운임 (3xx)
+	STATION_NOT_FOUND("존재하지 않는 역입니다.", HttpStatus.NOT_FOUND, "TRAIN_301"),
+	STATION_FARE_NOT_FOUND("해당 구간의 요금 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "TRAIN_302"),
+	INVALID_ROUTE("출발역과 도착역이 동일하거나 유효하지 않은 경로입니다.", HttpStatus.BAD_REQUEST, "TRAIN_303"),
+	SCHEDULE_STOP_NOT_FOUND("정류장 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "TRAIN_304"),
 
-	// 날짜, 시간 관련
-	OPERATION_DATE_TOO_FAR("예약 가능한 기간을 초과했습니다. (최대 1개월)", HttpStatus.BAD_REQUEST, "T4402"),
-	DEPARTURE_TIME_PASSED("선택하신 열차의 출발 시간이 이미 지났습니다.", HttpStatus.BAD_REQUEST, "T4404"),
-
-	// 검색 관련
-	NO_SEARCH_RESULTS("검색 조건에 맞는 열차가 없습니다.", HttpStatus.NOT_FOUND, "T4501");
+	// 날짜/검색 (4xx)
+	OPERATION_DATE_TOO_FAR("예약 가능한 기간을 초과했습니다. (최대 1개월)", HttpStatus.BAD_REQUEST, "TRAIN_401"),
+	DEPARTURE_TIME_PASSED("선택하신 열차의 출발 시간이 이미 지났습니다.", HttpStatus.BAD_REQUEST, "TRAIN_402"),
+	NO_SEARCH_RESULTS("검색 조건에 맞는 열차가 없습니다.", HttpStatus.NOT_FOUND, "TRAIN_403");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/main/java/com/sudo/raillo/train/exception/TrainErrorCode.java
+++ b/src/main/java/com/sudo/raillo/train/exception/TrainErrorCode.java
@@ -14,16 +14,11 @@ public enum TrainErrorCode implements ErrorCode {
 	// 열차 조회 관련
 	TRAIN_SCHEDULE_NOT_FOUND("해당 날짜에 운행하는 열차가 없습니다.", HttpStatus.NOT_FOUND, "T4001"),
 	TRAIN_OPERATION_CANCELLED("해당 열차는 운행이 취소되었습니다.", HttpStatus.BAD_REQUEST, "T4002"),
-	TRAIN_OPERATION_DELAYED("해당 열차는 지연 운행 중입니다.", HttpStatus.BAD_REQUEST, "T4003"),
 	TRAIN_SCHEDULE_DETAIL_NOT_FOUND("해당 열차 스케줄을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T4004"),
 	NO_AVAILABLE_CARS("잔여 좌석이 있는 객차가 없습니다.", HttpStatus.NOT_FOUND, "T_4005"),
 	TRAIN_CAR_NOT_FOUND("해당 객차를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T_4006"),
 
 	// 좌석 예약 관련
-	SEAT_NOT_AVAILABLE("선택한 좌석을 예약할 수 없습니다.", HttpStatus.BAD_REQUEST, "T4101"),
-	SEAT_ALREADY_EXISTED("이미 예약된 좌석입니다.", HttpStatus.CONFLICT, "T4102"),
-	INSUFFICIENT_SEATS("요청한 승객 수만큼 좌석이 부족합니다.", HttpStatus.BAD_REQUEST, "T4103"),
-	TRAIN_SOLD_OUT("해당 열차는 완전 매진되었습니다.", HttpStatus.BAD_REQUEST, "T4105"),
 	SEAT_NOT_FOUND("좌석을 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T4106"),
 
 	// 역 및 구간 관련
@@ -32,28 +27,12 @@ public enum TrainErrorCode implements ErrorCode {
 	INVALID_ROUTE("출발역과 도착역이 동일하거나 유효하지 않은 경로입니다.", HttpStatus.BAD_REQUEST, "T4203"),
 	SCHEDULE_STOP_NOT_FOUND("정류장 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T4204"),
 
-	// 승객 관련
-	INVALID_PASSENGER_COUNT("승객 수는 1명 이상 9명 이하여야 합니다.", HttpStatus.BAD_REQUEST, "T4301"),
-	PASSENGER_COUNT_EXCEEDS_LIMIT("한 번에 예약 가능한 최대 승객 수를 초과했습니다.", HttpStatus.BAD_REQUEST, "T4302"),
-
 	// 날짜, 시간 관련
-	INVALID_OPERATION_DATE("운행 날짜는 오늘 이후여야 합니다.", HttpStatus.BAD_REQUEST, "T4401"),
 	OPERATION_DATE_TOO_FAR("예약 가능한 기간을 초과했습니다. (최대 1개월)", HttpStatus.BAD_REQUEST, "T4402"),
-	NO_OPERATION_ON_DATE("해당 날짜와 운행하는 열차가 없습니다.", HttpStatus.NOT_FOUND, "T4403"),
 	DEPARTURE_TIME_PASSED("선택하신 열차의 출발 시간이 이미 지났습니다.", HttpStatus.BAD_REQUEST, "T4404"),
 
 	// 검색 관련
-	NO_SEARCH_RESULTS("검색 조건에 맞는 열차가 없습니다.", HttpStatus.NOT_FOUND, "T4501"),
-	INVALID_SEARCH_CONDITION("잘못된 검색 조건입니다.", HttpStatus.BAD_REQUEST, "T4502"),
-
-	// 예약 관련
-	BOOKING_NOT_FOUND("예약 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "T4601"),
-	BOOKING_ALREADY_CANCELLED("이미 취소된 예약입니다.", HttpStatus.BAD_REQUEST, "T4602"),
-	BOOKING_CANNOT_BE_CANCELLED("취소할 수 없는 예약입니다.", HttpStatus.BAD_REQUEST, "T4603"),
-
-	// 시스템 관련
-	TRAIN_SYSTEM_ERROR("열차 시스템 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, "T5001"),
-	EXTERNAL_API_ERROR("외부 API 연동 중 오류가 발생했습니다.", HttpStatus.SERVICE_UNAVAILABLE, "T5002");
+	NO_SEARCH_RESULTS("검색 조건에 맞는 열차가 없습니다.", HttpStatus.NOT_FOUND, "T4501");
 
 	private final String message;
 	private final HttpStatus status;

--- a/src/test/java/com/sudo/raillo/booking/application/PendingBookingServiceTest.java
+++ b/src/test/java/com/sudo/raillo/booking/application/PendingBookingServiceTest.java
@@ -30,7 +30,7 @@ import com.sudo.raillo.support.helper.TrainTestHelper;
 import com.sudo.raillo.train.domain.Seat;
 import com.sudo.raillo.train.domain.Train;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 
 @ServiceTest
 class PendingBookingServiceTest {
@@ -251,7 +251,7 @@ class PendingBookingServiceTest {
 		// when & then
 		assertThatThrownBy(() -> pendingBookingService.getPendingBookings(testMember.getMemberDetail().getMemberNo()))
 			.isInstanceOf(BusinessException.class)
-			.hasMessage(TrainErrorCode.TRAIN_SCHEDULE_NOT_FOUND.getMessage());
+			.hasMessage(TrainError.TRAIN_SCHEDULE_NOT_FOUND.getMessage());
 	}
 
 	@Test
@@ -277,7 +277,7 @@ class PendingBookingServiceTest {
 		// when & then
 		assertThatThrownBy(() -> pendingBookingService.getPendingBookings(testMember.getMemberDetail().getMemberNo()))
 			.isInstanceOf(BusinessException.class)
-			.hasMessage(TrainErrorCode.STATION_NOT_FOUND.getMessage());
+			.hasMessage(TrainError.STATION_NOT_FOUND.getMessage());
 	}
 
 	@Test
@@ -303,7 +303,7 @@ class PendingBookingServiceTest {
 		// when & then
 		assertThatThrownBy(() -> pendingBookingService.getPendingBookings(testMember.getMemberDetail().getMemberNo()))
 			.isInstanceOf(BusinessException.class)
-			.hasMessage(TrainErrorCode.SEAT_NOT_FOUND.getMessage());
+			.hasMessage(TrainError.SEAT_NOT_FOUND.getMessage());
 	}
 
 	@Test

--- a/src/test/java/com/sudo/raillo/booking/application/PendingBookingServiceTest.java
+++ b/src/test/java/com/sudo/raillo/booking/application/PendingBookingServiceTest.java
@@ -18,7 +18,6 @@ import com.sudo.raillo.booking.application.service.PendingBookingService;
 import com.sudo.raillo.booking.domain.PendingBooking;
 import com.sudo.raillo.booking.domain.PendingSeatBooking;
 import com.sudo.raillo.booking.domain.type.PassengerType;
-import com.sudo.raillo.booking.exception.BookingError;
 import com.sudo.raillo.booking.infrastructure.BookingRedisRepository;
 import com.sudo.raillo.global.exception.error.BusinessException;
 import com.sudo.raillo.member.domain.Member;
@@ -304,7 +303,7 @@ class PendingBookingServiceTest {
 		// when & then
 		assertThatThrownBy(() -> pendingBookingService.getPendingBookings(testMember.getMemberDetail().getMemberNo()))
 			.isInstanceOf(BusinessException.class)
-			.hasMessage(BookingError.SEAT_NOT_FOUND.getMessage());
+			.hasMessage(TrainErrorCode.SEAT_NOT_FOUND.getMessage());
 	}
 
 	@Test

--- a/src/test/java/com/sudo/raillo/booking/application/SeatConflictValidatorTest.java
+++ b/src/test/java/com/sudo/raillo/booking/application/SeatConflictValidatorTest.java
@@ -23,7 +23,7 @@ import com.sudo.raillo.train.domain.ScheduleStop;
 import com.sudo.raillo.train.domain.Seat;
 import com.sudo.raillo.train.domain.Train;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -434,7 +434,7 @@ public class SeatConflictValidatorTest {
 		assertThatThrownBy(() ->
 			bookingValidator.validateSeatConflicts(List.of(pendingBooking))
 		).isInstanceOf(BusinessException.class)
-			.hasFieldOrPropertyWithValue("errorCode", TrainErrorCode.SCHEDULE_STOP_NOT_FOUND);
+			.hasFieldOrPropertyWithValue("errorCode", TrainError.SCHEDULE_STOP_NOT_FOUND);
 	}
 
 	@Nested

--- a/src/test/java/com/sudo/raillo/booking/application/facade/PendingBookingFacadeTest.java
+++ b/src/test/java/com/sudo/raillo/booking/application/facade/PendingBookingFacadeTest.java
@@ -39,7 +39,7 @@ import com.sudo.raillo.train.domain.ScheduleStop;
 import com.sudo.raillo.train.domain.Seat;
 import com.sudo.raillo.train.domain.Train;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 
 @ServiceTest
 class PendingBookingFacadeTest {
@@ -227,7 +227,7 @@ class PendingBookingFacadeTest {
 		// when & then
 		assertThatThrownBy(() -> pendingBookingFacade.createPendingBooking(request, memberNo))
 			.isInstanceOf(BusinessException.class)
-			.hasFieldOrPropertyWithValue("errorCode", TrainErrorCode.DEPARTURE_TIME_PASSED);
+			.hasFieldOrPropertyWithValue("errorCode", TrainError.DEPARTURE_TIME_PASSED);
 	}
 
 	@Test
@@ -257,7 +257,7 @@ class PendingBookingFacadeTest {
 		// when & then
 		assertThatThrownBy(() -> pendingBookingFacade.createPendingBooking(request, memberNo))
 			.isInstanceOf(BusinessException.class)
-			.hasFieldOrPropertyWithValue("errorCode", TrainErrorCode.DEPARTURE_TIME_PASSED);
+			.hasFieldOrPropertyWithValue("errorCode", TrainError.DEPARTURE_TIME_PASSED);
 	}
 
 	@Test

--- a/src/test/java/com/sudo/raillo/fare/FareCalculatorTest.java
+++ b/src/test/java/com/sudo/raillo/fare/FareCalculatorTest.java
@@ -10,7 +10,7 @@ import com.sudo.raillo.support.helper.TrainScheduleTestHelper;
 import com.sudo.raillo.train.application.calculator.FareCalculator;
 import com.sudo.raillo.train.domain.Station;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Stream;
@@ -106,7 +106,7 @@ class FareCalculatorTest {
 			CarType.STANDARD
 		))
 			.isInstanceOf(BusinessException.class)
-			.hasFieldOrPropertyWithValue("errorCode", TrainErrorCode.STATION_FARE_NOT_FOUND);
+			.hasFieldOrPropertyWithValue("errorCode", TrainError.STATION_FARE_NOT_FOUND);
 	}
 
 	private static Stream<Arguments> provideStandardSeatScenarios() {

--- a/src/test/java/com/sudo/raillo/payment/application/metrics/PaymentMetricsTest.java
+++ b/src/test/java/com/sudo/raillo/payment/application/metrics/PaymentMetricsTest.java
@@ -159,7 +159,7 @@ class PaymentMetricsTest {
 	}
 
 	@Test
-	@DisplayName("금액 불일치로 결제 실패 시 payment_confirm_failure_total{reason=validation_error, error_code=P_011} 카운터가 증가한다")
+	@DisplayName("금액 불일치로 결제 실패 시 payment_confirm_failure_total{reason=validation_error, error_code=PAYMENT_201} 카운터가 증가한다")
 	void confirmPayment_amountMismatch_incrementsConfirmFailureValidationError() {
 		// given
 		BigDecimal orderAmount = BigDecimal.valueOf(50000);
@@ -222,7 +222,7 @@ class PaymentMetricsTest {
 	}
 
 	@Test
-	@DisplayName("5xx BusinessException 발생 시 payment_confirm_failure_total{reason=system_error, error_code=P_999} 카운터가 증가한다")
+	@DisplayName("5xx BusinessException 발생 시 payment_confirm_failure_total{reason=system_error, error_code=PAYMENT_901} 카운터가 증가한다")
 	void confirmPayment_5xxBusinessException_incrementsConfirmFailureSystemError() {
 		// given
 		BigDecimal amount = BigDecimal.valueOf(50000);

--- a/src/test/java/com/sudo/raillo/support/helper/BookingTestHelper.java
+++ b/src/test/java/com/sudo/raillo/support/helper/BookingTestHelper.java
@@ -21,7 +21,7 @@ import com.sudo.raillo.train.domain.ScheduleStop;
 import com.sudo.raillo.train.domain.Seat;
 import com.sudo.raillo.train.domain.Train;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.ScheduleStopRepository;
 import com.sudo.raillo.train.infrastructure.SeatRepository;
 import java.math.BigDecimal;
@@ -85,7 +85,7 @@ public class BookingTestHelper {
 
 		orderSeatBookings.forEach(osb -> {
 			Seat seat = seatRepository.findById(osb.getSeatId())
-				.orElseThrow(() -> new BusinessException(TrainErrorCode.SEAT_NOT_FOUND));
+				.orElseThrow(() -> new BusinessException(TrainError.SEAT_NOT_FOUND));
 			builder.addSeat(seat, osb.getPassengerType());
 		});
 		return builder.build();

--- a/src/test/java/com/sudo/raillo/train/application/facade/TrainSearchFacadeCarAndSeatTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/facade/TrainSearchFacadeCarAndSeatTest.java
@@ -25,7 +25,7 @@ import com.sudo.raillo.train.domain.Station;
 import com.sudo.raillo.train.domain.Train;
 import com.sudo.raillo.train.domain.TrainCar;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.TrainCarRepository;
 import java.time.Duration;
 import java.util.Collection;
@@ -330,7 +330,7 @@ public class TrainSearchFacadeCarAndSeatTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchFacade.getAvailableTrainCars(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.NO_AVAILABLE_CARS.getMessage());
+			.hasMessageContaining(TrainError.NO_AVAILABLE_CARS.getMessage());
 	}
 
 	@DisplayName("SeatBooking과 Seat Hold가 함께 존재하면 둘 다 차감된다")

--- a/src/test/java/com/sudo/raillo/train/application/facade/TrainSearchFacadeValidationTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/facade/TrainSearchFacadeValidationTest.java
@@ -24,7 +24,7 @@ import com.sudo.raillo.train.application.dto.request.TrainSearchRequest;
 import com.sudo.raillo.train.application.dto.response.TrainSearchSlicePageResponse;
 import com.sudo.raillo.train.domain.Station;
 import com.sudo.raillo.train.domain.Train;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -78,9 +78,9 @@ public class TrainSearchFacadeValidationTest {
 			.satisfies(ex -> {
 				BusinessException be = (BusinessException)ex;
 				assertThat(be.getErrorCode())
-					.isEqualTo(TrainErrorCode.STATION_FARE_NOT_FOUND);
+					.isEqualTo(TrainError.STATION_FARE_NOT_FOUND);
 				assertThat(be.getMessage())
-					.contains(TrainErrorCode.STATION_FARE_NOT_FOUND.getMessage());
+					.contains(TrainError.STATION_FARE_NOT_FOUND.getMessage());
 			});
 	}
 
@@ -96,7 +96,7 @@ public class TrainSearchFacadeValidationTest {
 			String description,
 			TrainSearchRequest request,
 			Class<? extends Exception> expectedException,
-			TrainErrorCode expectedErrorCode,
+			TrainError expectedErrorCode,
 			String expectedMessageContains
 		) {}
 
@@ -105,15 +105,15 @@ public class TrainSearchFacadeValidationTest {
 				"출발역과 도착역이 동일한 경우",
 				new TrainSearchRequest(seoul.getId(), seoul.getId(), validDate, 1, "00"),
 				BusinessException.class,
-				TrainErrorCode.INVALID_ROUTE,
-				TrainErrorCode.INVALID_ROUTE.getMessage()
+				TrainError.INVALID_ROUTE,
+				TrainError.INVALID_ROUTE.getMessage()
 			),
 			new ValidationScenario(
 				"운행일이 너무 먼 미래인 경우 (3개월 후)",
 				new TrainSearchRequest(seoul.getId(), busan.getId(), LocalDate.now().plusMonths(3), 1, "00"),
 				BusinessException.class,
-				TrainErrorCode.OPERATION_DATE_TOO_FAR,
-				TrainErrorCode.OPERATION_DATE_TOO_FAR.getMessage()
+				TrainError.OPERATION_DATE_TOO_FAR,
+				TrainError.OPERATION_DATE_TOO_FAR.getMessage()
 			)
 		);
 
@@ -152,7 +152,7 @@ public class TrainSearchFacadeValidationTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchFacade.searchTrains(request, PageRequest.of(0, 20)))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.DEPARTURE_TIME_PASSED.getMessage());
+			.hasMessageContaining(TrainError.DEPARTURE_TIME_PASSED.getMessage());
 	}
 
 	@DisplayName("다양한 검색 시나리오에서 검색 결과가 없을 경우 빈 리스트를 반환한다.")

--- a/src/test/java/com/sudo/raillo/train/application/service/CarRecommendationServiceTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/service/CarRecommendationServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import com.sudo.raillo.global.exception.error.BusinessException;
 import com.sudo.raillo.train.application.dto.response.TrainCarInfo;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,7 +66,7 @@ class CarRecommendationServiceTest {
 		// when & then
 		assertThatThrownBy(() -> service.selectRecommendedCar(cars, passengerCount))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.NO_AVAILABLE_CARS.getMessage());
+			.hasMessageContaining(TrainError.NO_AVAILABLE_CARS.getMessage());
 
 		log.info("객차 없음 예외 테스트 완료");
 	}

--- a/src/test/java/com/sudo/raillo/train/application/service/TrainSearchServiceTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/service/TrainSearchServiceTest.java
@@ -39,7 +39,7 @@ import com.sudo.raillo.train.domain.TrainSchedule;
 import com.sudo.raillo.train.domain.status.OperationStatus;
 import com.sudo.raillo.train.domain.type.CarType;
 import com.sudo.raillo.train.domain.type.TrainType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.SeatBookingQueryRepository;
 import com.sudo.raillo.train.infrastructure.StationFareRepository;
 import com.sudo.raillo.train.infrastructure.TrainScheduleQueryRepository;
@@ -161,7 +161,7 @@ class TrainSearchServiceTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchService.findStationFare(departureStationId, arrivalStationId))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.STATION_FARE_NOT_FOUND.getMessage());
+			.hasMessageContaining(TrainError.STATION_FARE_NOT_FOUND.getMessage());
 
 		verify(stationFareRepository).findByDepartureStationIdAndArrivalStationId(
 			departureStationId, arrivalStationId
@@ -221,7 +221,7 @@ class TrainSearchServiceTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchService.getTrainScheduleBasicInfo(trainScheduleId))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.TRAIN_SCHEDULE_DETAIL_NOT_FOUND.getMessage());
+			.hasMessageContaining(TrainError.TRAIN_SCHEDULE_DETAIL_NOT_FOUND.getMessage());
 
 		verify(trainScheduleRepository).findById(trainScheduleId);
 	}

--- a/src/test/java/com/sudo/raillo/train/application/service/TrainSeatQueryServiceTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/service/TrainSeatQueryServiceTest.java
@@ -22,7 +22,7 @@ import com.sudo.raillo.train.domain.Seat;
 import com.sudo.raillo.train.domain.Train;
 import com.sudo.raillo.train.domain.TrainCar;
 import com.sudo.raillo.train.domain.type.CarType;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.TrainCarRepository;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -153,7 +153,7 @@ class TrainSeatQueryServiceTest {
 			arrivalStop.getStation().getId()
 		))
 			.isInstanceOf(BusinessException.class)
-			.hasMessage(TrainErrorCode.NO_AVAILABLE_CARS.getMessage());
+			.hasMessage(TrainError.NO_AVAILABLE_CARS.getMessage());
 	}
 
 	@Test

--- a/src/test/java/com/sudo/raillo/train/application/validator/TrainSearchValidatorTest.java
+++ b/src/test/java/com/sudo/raillo/train/application/validator/TrainSearchValidatorTest.java
@@ -22,7 +22,7 @@ import com.sudo.raillo.global.exception.error.BusinessException;
 import com.sudo.raillo.train.application.dto.request.TrainCarListRequest;
 import com.sudo.raillo.train.application.dto.request.TrainCarSeatDetailRequest;
 import com.sudo.raillo.train.application.dto.request.TrainSearchRequest;
-import com.sudo.raillo.train.exception.TrainErrorCode;
+import com.sudo.raillo.train.exception.TrainError;
 import com.sudo.raillo.train.infrastructure.StationRepository;
 import com.sudo.raillo.train.infrastructure.TrainCarRepository;
 import com.sudo.raillo.train.infrastructure.TrainScheduleRepository;
@@ -63,7 +63,7 @@ class TrainSearchValidatorTest {
 		record ValidationScenario(
 			String description,
 			TrainSearchRequest request,
-			TrainErrorCode expectedErrorCode
+			TrainError expectedErrorCode
 		) {
 			@Override
 			public String toString() {
@@ -75,17 +75,17 @@ class TrainSearchValidatorTest {
 			new ValidationScenario(
 				"출발역과 도착역이 동일한 경우",
 				new TrainSearchRequest(1L, 1L, LocalDate.now().plusDays(1), 2, "10"),
-				TrainErrorCode.INVALID_ROUTE
+				TrainError.INVALID_ROUTE
 			),
 			new ValidationScenario(
 				"운행일이 1개월 이상 미래인 경우",
 				new TrainSearchRequest(1L, 2L, LocalDate.now().plusMonths(2), 2, "10"),
-				TrainErrorCode.OPERATION_DATE_TOO_FAR
+				TrainError.OPERATION_DATE_TOO_FAR
 			),
 			new ValidationScenario(
 				"오늘 날짜에 과거 시간을 선택한 경우",
 				new TrainSearchRequest(1L, 2L, LocalDate.now(), 2, pastHourString),
-				TrainErrorCode.DEPARTURE_TIME_PASSED
+				TrainError.DEPARTURE_TIME_PASSED
 			)
 		);
 
@@ -93,7 +93,7 @@ class TrainSearchValidatorTest {
 			.map(scenario -> DynamicTest.dynamicTest(
 				scenario.description,
 				() -> {
-					if (scenario.expectedErrorCode == TrainErrorCode.DEPARTURE_TIME_PASSED) {
+					if (scenario.expectedErrorCode == TrainError.DEPARTURE_TIME_PASSED) {
 						Assumptions.assumeTrue(canTestPastTime,
 							"현재 시각이 자정(00시)이므로 과거 시간 테스트를 건너뛴다.");
 					}
@@ -158,7 +158,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateTrainCarListRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.TRAIN_SCHEDULE_NOT_FOUND.getMessage());
+			.hasMessageContaining(TrainError.TRAIN_SCHEDULE_NOT_FOUND.getMessage());
 
 		verify(trainScheduleRepository).existsById(999L);
 		log.info("존재하지 않는 열차 스케줄 검증 예외 발생 완료");
@@ -175,7 +175,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateTrainCarListRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.STATION_NOT_FOUND.getMessage());
+			.hasMessageContaining(TrainError.STATION_NOT_FOUND.getMessage());
 
 		verify(stationRepository).existsById(999L);
 		log.info("존재하지 않는 출발역 검증 예외 발생 완료");
@@ -193,7 +193,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateTrainCarListRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.STATION_NOT_FOUND.getMessage());
+			.hasMessageContaining(TrainError.STATION_NOT_FOUND.getMessage());
 
 		verify(stationRepository).existsById(999L);
 		log.info("존재하지 않는 도착역 검증 예외 발생 완료");
@@ -210,7 +210,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateTrainCarListRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.INVALID_ROUTE.getMessage());
+			.hasMessageContaining(TrainError.INVALID_ROUTE.getMessage());
 
 		log.info("출발역과 도착역이 동일한 경우 검증 예외 발생 완료");
 	}
@@ -245,7 +245,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateTrainCarSeatDetailRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.TRAIN_CAR_NOT_FOUND.getMessage());
+			.hasMessageContaining(TrainError.TRAIN_CAR_NOT_FOUND.getMessage());
 
 		verify(trainCarRepository).existsById(999L);
 		log.info("존재하지 않는 객차 검증 예외 발생 완료");
@@ -262,7 +262,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateTrainCarSeatDetailRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.TRAIN_SCHEDULE_NOT_FOUND.getMessage());
+			.hasMessageContaining(TrainError.TRAIN_SCHEDULE_NOT_FOUND.getMessage());
 
 		verify(trainScheduleRepository).existsById(999L);
 		log.info("존재하지 않는 열차 스케줄 검증 예외 발생 완료");
@@ -280,7 +280,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateTrainCarSeatDetailRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.STATION_NOT_FOUND.getMessage());
+			.hasMessageContaining(TrainError.STATION_NOT_FOUND.getMessage());
 
 		verify(stationRepository).existsById(999L);
 		log.info("존재하지 않는 출발역 검증 예외 발생 완료");
@@ -298,7 +298,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateTrainCarSeatDetailRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.INVALID_ROUTE.getMessage());
+			.hasMessageContaining(TrainError.INVALID_ROUTE.getMessage());
 
 		log.info("출발역과 도착역이 동일한 경우 검증 예외 발생 완료");
 	}
@@ -355,7 +355,7 @@ class TrainSearchValidatorTest {
 		// when & then
 		assertThatThrownBy(() -> trainSearchValidator.validateScheduleSearchRequest(request))
 			.isInstanceOf(BusinessException.class)
-			.hasMessageContaining(TrainErrorCode.OPERATION_DATE_TOO_FAR.getMessage());
+			.hasMessageContaining(TrainError.OPERATION_DATE_TOO_FAR.getMessage());
 
 		log.info("1개월 + 1일 후 날짜 검증 예외 발생: {}", oneMonthAndOneDayLater);
 	}


### PR DESCRIPTION
## 관련 Issue (필수)
- close #241

## 주요 변경 사항 (필수)
도메인별 `ErrorCode` enum의 네이밍·코드 포맷·번호 체계를 통일하고, 미사용/중복을 정리했습니다.

**1. enum 클래스명 통일** — `TrainErrorCode` → `TrainError` (나머지 8개 도메인 `{Domain}Error` 규칙에 맞춤)

**2. 코드 문자열 신규 스킴** — `{DOMAIN}_{NNN}` (풀워드 접두사 + 백의 자리 카테고리 밴드)

| 도메인 | 기존 | 신규 |
|--------|------|------|
| auth | `E_`/`T_` | `AUTH_`/`TOKEN_` |
| booking | `B_`·`B` 혼용 | `BOOKING_` |
| train | `T`·`T_` | `TRAIN_` |
| payment | `P_`·`P_0203` | `PAYMENT_` |
| member/order/redis/global | `M_`/`O_`/`R_`/`G_` | `MEMBER_`/`ORDER_`/`REDIS_`/`GLOBAL_` |

→ 접두사 충돌(`T`: Token↔Train)·`E_`(auth) 미스매치·언더스코어/자릿수 혼용 해소

**3. 미사용 상수 43개 삭제** — 전체 130개 중 33%가 main/test 0-참조 (YAGNI, git 이력 보존)

**4. 살아있는 중복 통합** — `SEAT_NOT_FOUND`를 `Seat` 엔티티 소유 도메인인 `TrainError`로 일원화 (BookingValidator repoint)

**5. 하드코딩 정리** — `GlobalExceptionHandler`의 `"G_400"`(enum 미존재) → `GlobalError.REQUEST_BODY_MISSING`(GLOBAL_009)

**6. 도메인 용어 정정** — 에러 메시지 `임시 예약`→`예약`(PendingBooking), SeatBooking `예약`→`예매`

**7. 컨벤션 문서화** — `docs/error-code-convention.md` 신규 + `AGENTS.md` 링크 + `ErrorCode` Javadoc

## 리뷰어 참고 사항
없음

## 추가 정보
없음

## PR 작성 체크리스트 (필수)
- [x] 제목이 Issue와 동일함을 확인했습니다.